### PR TITLE
chore: ignore vendored avatar source in ESLint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,6 +13,9 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+
+    // Vendored third-party code (kept as-is; linting it adds noise).
+    "src/lib/avatars/vendor/**",
   ]),
   prettier,
 ]);

--- a/src/app/api/projects/[projectId]/tiles/[tileId]/workspace-files/route.ts
+++ b/src/app/api/projects/[projectId]/tiles/[tileId]/workspace-files/route.ts
@@ -4,7 +4,6 @@ import fs from "node:fs";
 
 import { logger } from "@/lib/logger";
 import { resolveAgentWorkspaceDir } from "@/lib/projects/agentWorkspace";
-import { WORKSPACE_FILE_NAMES } from "@/lib/projects/workspaceFiles";
 import {
   readWorkspaceFiles,
   writeWorkspaceFiles,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -430,7 +430,7 @@ const AgentCanvasPage = () => {
     return () => {
       cancelled = true;
     };
-  }, [client, status]);
+  }, [buildAllowedModelKeys, client, status]);
 
   useEffect(() => {
     const node = viewportRef.current;

--- a/src/features/canvas/components/CanvasFlow.tsx
+++ b/src/features/canvas/components/CanvasFlow.tsx
@@ -162,7 +162,7 @@ const CanvasFlowInner = ({
   );
 
   useEffect(() => {
-    setNodes((prevNodes) =>
+    setNodes(() =>
       nodesFromTiles.map((node) => {
         const override = resizeOverridesRef.current.get(node.id);
         if (!override) return node;


### PR DESCRIPTION
### What
- Ignore vendored avatar generator source (`src/lib/avatars/vendor/**`) in ESLint.
- Fix a couple small lint warnings in app code (unused import + effect deps + unused callback arg).

### Why
The vendored `multiavatar.js` file triggers a large number of false-positive warnings that drown out actionable lint feedback.

### Notes
Tests: `npm test` (vitest) ✅
Lint: `npm run lint` (now only 1 remaining Next.js `<img>` warning in `AgentAvatar.tsx`) ⚠️