### PR TITLE
chore: fix lint warnings (Image + effect deps)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -836,7 +836,7 @@ const AgentCanvasPage = () => {
       }
       unsubscribe();
     };
-  }, [client, loadSummarySnapshot, status]);
+  }, [client, loadSummarySnapshot, refreshHeartbeatLatestUpdate, status]);
 
   useEffect(() => {
     const node = viewportRef.current;

--- a/src/features/canvas/components/AgentAvatar.tsx
+++ b/src/features/canvas/components/AgentAvatar.tsx
@@ -1,3 +1,4 @@
+import Image from "next/image";
 import { useMemo } from "react";
 
 import { buildAvatarDataUrl } from "@/lib/avatars/multiavatar";
@@ -22,10 +23,13 @@ export const AgentAvatar = ({
       className={`flex items-center justify-center overflow-hidden rounded-full border border-border bg-card shadow-sm ${isSelected ? "agent-avatar-selected" : ""}`}
       style={{ width: size, height: size }}
     >
-      <img
+      <Image
         className="h-full w-full select-none pointer-events-none"
         src={src}
         alt={`Avatar for ${name}`}
+        width={size}
+        height={size}
+        unoptimized
         draggable={false}
       />
     </div>


### PR DESCRIPTION
## What
- Fixes a missing dependency in the main subscription `useEffect` (adds `refreshHeartbeatLatestUpdate` to deps).
- Switches `AgentAvatar` from `<img>` to `next/image` (with `unoptimized`) to satisfy Next linting for data-URL avatars.

## Why
- Keeps `npm run lint` clean and avoids ignoring legitimate hook-deps warnings.
- Aligns with Next.js best practices and reduces future CI noise.

## Checks
- `npm run lint`
- `npm test`
