### PR TITLE
chore(lint): clean up eslint warnings

### DIFF
--- a/src/features/canvas/components/AgentInspectPanel.tsx
+++ b/src/features/canvas/components/AgentInspectPanel.tsx
@@ -331,6 +331,7 @@ export const AgentInspectPanel = ({
     heartbeatTargetMode,
     client,
     tile.agentId,
+    tile.sessionKey,
   ]);
 
   useEffect(() => {


### PR DESCRIPTION
This PR removes a few eslint warnings that appeared on main after recent merges.

Changes
- Remove unused locals in src/app/page.tsx (clearError, selectedAgent).
- Remove unused computeNewTilePosition helper (and drop the now-unused worldToScreen import).
- Fix react-hooks/exhaustive-deps warning by removing the imported updateStudioSettings function from a dependency array.
- Fix AgentInspectPanel callback deps by including tile.sessionKey.

Verification
- npm run lint (clean)
- npm test -- --run (pass)
