### PR TITLE
Fix gateway token persistence on initial load

### DIFF
--- a/tests/e2e/connection-settings.spec.ts
+++ b/tests/e2e/connection-settings.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 test("connection settings persist to the studio settings API", async ({ page }) => {
+  let putCount = 0;
   await page.route("**/api/studio", async (route, request) => {
     if (request.method() === "GET") {
       await route.fulfill({
@@ -13,6 +14,7 @@ test("connection settings persist to the studio settings API", async ({ page }) 
       return;
     }
     if (request.method() === "PUT") {
+      putCount += 1;
       const payload = JSON.parse(request.postData() ?? "{}") as Record<string, unknown>;
       await route.fulfill({
         status: 200,
@@ -34,6 +36,9 @@ test("connection settings persist to the studio settings API", async ({ page }) 
   await page.goto("/");
   await page.getByTestId("studio-menu-toggle").click();
   await page.getByTestId("gateway-settings-toggle").click();
+
+  await page.waitForTimeout(600);
+  expect(putCount).toBe(0);
 
   await page.getByLabel("Gateway URL").fill("ws://gateway.example:18789");
   await page.getByLabel("Token").fill("token-123");


### PR DESCRIPTION
**Summary**
Prevents Studio from persisting default gateway settings on initial load.
This avoids wiping a previously-saved token with the hook's initial `token = ""` state.

**Why**
Studio was scheduling a settings write as soon as settings finished loading, even when the current `{ url, token }` was just the initial/default state.
That creates an easy-to-hit path where an empty token can get written back out.

**Changes**
- Track the gateway `{ url, token }` baseline that was loaded (or defaults) inside `useGatewayConnection`.
- Gate persistence until settings are loaded and the current values differ from that baseline.
- Update Playwright e2e coverage to assert there is no initial `PUT /api/studio` before the user edits.

**Testing**
Updated e2e test: `tests/e2e/connection-settings.spec.ts`.
