### PR TITLE
Retain selected agent after refresh

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -333,6 +333,7 @@ const AgentStudioPage = () => {
   );
   const specialUpdateRef = useRef<Map<string, string>>(new Map());
   const specialUpdateInFlightRef = useRef<Set<string>>(new Set());
+  const preferredSelectedAgentIdRef = useRef<string | null>(null);
   const pendingCreateSetupsByAgentIdRef = useRef<Record<string, AgentGuidedSetup>>({});
   const pendingDraftValuesRef = useRef<Map<string, string>>(new Map());
   const pendingDraftTimersRef = useRef<Map<string, number>>(new Map());
@@ -695,7 +696,17 @@ const AgentStudioPage = () => {
       if (!gatewayConfigSnapshot && result.configSnapshot) {
         setGatewayConfigSnapshot(result.configSnapshot);
       }
-      hydrateAgents(result.seeds);
+      const preferredSelectedAgentId = preferredSelectedAgentIdRef.current?.trim() ?? "";
+      const hasCurrentSelection = Boolean(stateRef.current.selectedAgentId);
+      const preferredSelectedAgentExists =
+        preferredSelectedAgentId.length > 0 &&
+        result.seeds.some((seed) => seed.agentId === preferredSelectedAgentId);
+      const initialSelectedAgentId = hasCurrentSelection
+        ? undefined
+        : preferredSelectedAgentExists
+          ? preferredSelectedAgentId
+          : result.suggestedSelectedAgentId ?? undefined;
+      hydrateAgents(result.seeds, initialSelectedAgentId);
       const sessionSettingsSyncedAgentIds = new Set(result.sessionSettingsSyncedAgentIds);
       for (const agentId of result.sessionCreatedAgentIds) {
         dispatch({
@@ -713,9 +724,6 @@ const AgentStudioPage = () => {
           agentId: entry.agentId,
           patch: entry.patch,
         });
-      }
-      if (result.suggestedSelectedAgentId) {
-        dispatch({ type: "selectAgent", agentId: result.suggestedSelectedAgentId });
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to load agents.";
@@ -814,11 +822,13 @@ const AgentStudioPage = () => {
     let cancelled = false;
     const key = gatewayUrl.trim();
     if (!key) {
+      preferredSelectedAgentIdRef.current = null;
       setFocusedPreferencesLoaded(true);
       return;
     }
     setFocusedPreferencesLoaded(false);
     focusFilterTouchedRef.current = false;
+    preferredSelectedAgentIdRef.current = null;
     const loadFocusedPreferences = async () => {
       try {
         const settings = await settingsCoordinator.loadSettings();
@@ -830,9 +840,11 @@ const AgentStudioPage = () => {
         }
         const preference = resolveFocusedPreference(settings, key);
         if (preference) {
+          preferredSelectedAgentIdRef.current = preference.selectedAgentId;
           setFocusFilter(preference.filter);
           return;
         }
+        preferredSelectedAgentIdRef.current = null;
         setFocusFilter("all");
       } catch (err) {
         console.error("Failed to load focused preference.", err);
@@ -870,6 +882,31 @@ const AgentStudioPage = () => {
       300
     );
   }, [focusFilter, gatewayUrl, settingsCoordinator]);
+
+  useEffect(() => {
+    const key = gatewayUrl.trim();
+    if (!key) return;
+    if (status !== "connected") return;
+    if (!focusedPreferencesLoaded || !agentsLoadedOnce) return;
+    settingsCoordinator.schedulePatch(
+      {
+        focused: {
+          [key]: {
+            mode: "focused",
+            selectedAgentId: state.selectedAgentId,
+          },
+        },
+      },
+      300
+    );
+  }, [
+    agentsLoadedOnce,
+    focusedPreferencesLoaded,
+    gatewayUrl,
+    settingsCoordinator,
+    status,
+    state.selectedAgentId,
+  ]);
 
   useEffect(() => {
     if (status !== "connected" || !focusedPreferencesLoaded) return;

--- a/src/features/agents/state/store.tsx
+++ b/src/features/agents/state/store.tsx
@@ -114,7 +114,7 @@ export type AgentStoreState = {
 };
 
 type Action =
-  | { type: "hydrateAgents"; agents: AgentStoreSeed[] }
+  | { type: "hydrateAgents"; agents: AgentStoreSeed[]; selectedAgentId?: string }
   | { type: "setError"; error: string | null }
   | { type: "setLoading"; loading: boolean }
   | { type: "updateAgent"; agentId: string; patch: Partial<AgentState> }
@@ -236,8 +236,13 @@ const reducer = (state: AgentStoreState, action: Action): AgentStoreState => {
       const agents = action.agents.map((seed) =>
         createRuntimeAgentState(seed, byId.get(seed.agentId))
       );
+      const requestedSelectedAgentId = action.selectedAgentId?.trim() ?? "";
       const selectedAgentId =
-        state.selectedAgentId && agents.some((agent) => agent.agentId === state.selectedAgentId)
+        requestedSelectedAgentId &&
+        agents.some((agent) => agent.agentId === requestedSelectedAgentId)
+          ? requestedSelectedAgentId
+          : state.selectedAgentId &&
+              agents.some((agent) => agent.agentId === state.selectedAgentId)
           ? state.selectedAgentId
           : agents[0]?.agentId ?? null;
       return {
@@ -398,7 +403,7 @@ export const initialAgentStoreState = initialState;
 type AgentStoreContextValue = {
   state: AgentStoreState;
   dispatch: React.Dispatch<Action>;
-  hydrateAgents: (agents: AgentStoreSeed[]) => void;
+  hydrateAgents: (agents: AgentStoreSeed[], selectedAgentId?: string) => void;
   setLoading: (loading: boolean) => void;
   setError: (error: string | null) => void;
 };
@@ -409,8 +414,8 @@ export const AgentStoreProvider = ({ children }: { children: ReactNode }) => {
   const [state, dispatch] = useReducer(reducer, initialState);
 
   const hydrateAgents = useCallback(
-    (agents: AgentStoreSeed[]) => {
-      dispatch({ type: "hydrateAgents", agents });
+    (agents: AgentStoreSeed[], selectedAgentId?: string) => {
+      dispatch({ type: "hydrateAgents", agents, selectedAgentId });
     },
     [dispatch]
   );

--- a/tests/unit/agentStore.test.ts
+++ b/tests/unit/agentStore.test.ts
@@ -28,6 +28,56 @@ describe("agent store", () => {
     expect(next.agents[0].outputLines).toEqual([]);
   });
 
+  it("hydrates agents with a requested selection when present", () => {
+    const seeds: AgentStoreSeed[] = [
+      {
+        agentId: "agent-1",
+        name: "Agent One",
+        sessionKey: "agent:agent-1:main",
+      },
+      {
+        agentId: "agent-2",
+        name: "Agent Two",
+        sessionKey: "agent:agent-2:main",
+      },
+    ];
+    const next = agentStoreReducer(initialAgentStoreState, {
+      type: "hydrateAgents",
+      agents: seeds,
+      selectedAgentId: " agent-2 ",
+    });
+    expect(next.selectedAgentId).toBe("agent-2");
+  });
+
+  it("keeps existing selection when requested selection is invalid", () => {
+    const seeds: AgentStoreSeed[] = [
+      {
+        agentId: "agent-1",
+        name: "Agent One",
+        sessionKey: "agent:agent-1:main",
+      },
+      {
+        agentId: "agent-2",
+        name: "Agent Two",
+        sessionKey: "agent:agent-2:main",
+      },
+    ];
+    let state = agentStoreReducer(initialAgentStoreState, {
+      type: "hydrateAgents",
+      agents: seeds,
+    });
+    state = agentStoreReducer(state, {
+      type: "selectAgent",
+      agentId: "agent-2",
+    });
+    state = agentStoreReducer(state, {
+      type: "hydrateAgents",
+      agents: seeds,
+      selectedAgentId: "missing-agent",
+    });
+    expect(state.selectedAgentId).toBe("agent-2");
+  });
+
   it("builds a patch that resets runtime state for a session reset", () => {
     const seed: AgentStoreSeed = {
       agentId: "agent-1",


### PR DESCRIPTION
Summary
- hydrateAgents now honors a requested `selectedAgentId` and we track the preferred agent via focused preferences so the sidebar restores the same item after reload (src/app/page.tsx:695).
- Added middleware that persists the active agent selection into focused preferences whenever agents are loaded and the gateway is connected (src/app/page.tsx:814).
- Extended the agent store to accept a desired selection and added unit tests covering the new behavior (src/features/agents/state/store.tsx:236, tests/unit/agentStore.test.ts:28).

Testing
- Not run (not requested)