### PR TITLE
Fix agent chat spacing

### DIFF
--- a/src/app/styles/markdown.css
+++ b/src/app/styles/markdown.css
@@ -1,6 +1,6 @@
 .agent-markdown {
   display: block;
-  white-space: pre-wrap;
+  white-space: normal;
   word-break: break-word;
   line-height: 1.56;
 }
@@ -61,6 +61,10 @@
 
 .agent-markdown li {
   margin-top: 0.15rem;
+}
+
+.agent-markdown li > p {
+  margin: 0;
 }
 
 .agent-markdown code {


### PR DESCRIPTION
Summary
- Tighten `.agent-markdown` so chat messages render with `white-space: normal`, which prevents the large vertical gaps from `pre-wrap`.
- Remove extra margins from `.agent-markdown li > p` so list items display without unexpected spacing.

Testing
- Not run (not requested)