### PR TITLE
Queue agent creation while leaving modal open

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1643,7 +1643,7 @@ const AgentStudioPage = () => {
         startedAt: queuedCreateBlock.startedAt,
       });
       try {
-        await enqueueConfigMutation({
+        const queuedMutation = enqueueConfigMutation({
           kind: "create-agent",
           label: `Create ${name}`,
           run: async () => {
@@ -1711,6 +1711,8 @@ const AgentStudioPage = () => {
             }
           },
         });
+        setCreateAgentModalOpen(false);
+        await queuedMutation;
       } catch (err) {
         const message = err instanceof Error ? err.message : "Failed to create agent.";
         setCreateAgentBlock(null);


### PR DESCRIPTION
## Summary
- close the create-agent modal immediately after enqueueing the config mutation
- wait for the queued mutation to finish so the creation flow still completes even though the modal is gone

## Testing
- Not run (not requested)