### PR TITLE
Add execution role controls to agent settings

### DIFF
--- a/src/features/agents/operations/useConfigMutationQueue.ts
+++ b/src/features/agents/operations/useConfigMutationQueue.ts
@@ -4,7 +4,11 @@ import { shouldStartNextConfigMutation } from "@/features/agents/operations/conf
 import type { GatewayStatus } from "@/features/agents/operations/gatewayRestartPolicy";
 import { randomUUID } from "@/lib/uuid";
 
-export type ConfigMutationKind = "create-agent" | "rename-agent" | "delete-agent";
+export type ConfigMutationKind =
+  | "create-agent"
+  | "rename-agent"
+  | "delete-agent"
+  | "update-agent-execution-role";
 
 type QueuedConfigMutation = {
   id: string;

--- a/src/features/agents/state/transcript.ts
+++ b/src/features/agents/state/transcript.ts
@@ -195,11 +195,11 @@ const hasNumericTimestamp = (value: number | null): value is number => {
 };
 
 const compareEntries = (a: TranscriptEntry, b: TranscriptEntry): number => {
-  const aHasTs = hasNumericTimestamp(a.timestampMs);
-  const bHasTs = hasNumericTimestamp(b.timestampMs);
+  const aTimestamp = a.timestampMs;
+  const bTimestamp = b.timestampMs;
+  const aHasTs = hasNumericTimestamp(aTimestamp);
+  const bHasTs = hasNumericTimestamp(bTimestamp);
   if (aHasTs && bHasTs) {
-    const aTimestamp = a.timestampMs;
-    const bTimestamp = b.timestampMs;
     if (aTimestamp !== bTimestamp) {
       return aTimestamp - bTimestamp;
     }

--- a/tests/unit/agentBrainPanel.test.ts
+++ b/tests/unit/agentBrainPanel.test.ts
@@ -95,7 +95,7 @@ describe("AgentBrainPanel", () => {
     vi.unstubAllGlobals();
   });
 
-  it("renders_guided_personality_fields_instead_of_file_tabs", async () => {
+  it("renders_file_tabs_and_loads_agent_files", async () => {
     const { client } = createMockClient();
     const agents = [
       createAgent("agent-1", "Alpha", "session-1"),
@@ -112,12 +112,14 @@ describe("AgentBrainPanel", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByLabelText("Identity name")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: "AGENTS" })).toBeInTheDocument();
     });
 
-    expect(screen.queryByRole("button", { name: "AGENTS" })).not.toBeInTheDocument();
-    expect(screen.getByDisplayValue("Alpha")).toBeInTheDocument();
-    expect(screen.getByDisplayValue("GP")).toBeInTheDocument();
+    expect(screen.getByText("alpha agents")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "IDENTITY" }));
+    await waitFor(() => {
+      expect(screen.getByText("Name: Alpha")).toBeInTheDocument();
+    });
   });
 
   it("shows_actionable_message_when_session_key_missing", async () => {
@@ -152,8 +154,18 @@ describe("AgentBrainPanel", () => {
       })
     );
 
-    const input = await screen.findByLabelText("Identity name");
-    fireEvent.change(input, { target: { value: "Alpha Prime" } });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "IDENTITY" })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "IDENTITY" }));
+    fireEvent.click(screen.getByRole("button", { name: "Edit" }));
+    const textarea = await screen.findByRole("textbox");
+    fireEvent.change(textarea, {
+      target: {
+        value:
+          "# IDENTITY.md - Who Am I?\n\n- Name: Alpha Prime\n- Creature: droid\n- Vibe: calm\n- Emoji: 🤖\n",
+      },
+    });
     fireEvent.click(screen.getByTestId("agent-brain-close"));
 
     await waitFor(() => {


### PR DESCRIPTION
Summary
- surface execution role selection in the agent settings panel with conservative/collaborative/autonomous options and persist the selection via mutations
- introduce new gateway execution approval reads/writes so settings can update both approvals and overrides atomically
- refresh agent list after role updates and adjust unit test expectations for the agent brain panel

Testing
- Not run (not requested)