### PR TITLE
Prefer model alias in dropdown labels

### DIFF
--- a/src/features/agents/components/AgentChatPanel.tsx
+++ b/src/features/agents/components/AgentChatPanel.tsx
@@ -977,14 +977,15 @@ export const AgentChatPanel = ({
 
   const modelOptions = useMemo(
     () =>
-      models.map((entry) => ({
-        value: `${entry.provider}/${entry.id}`,
-        label:
-          entry.name === `${entry.provider}/${entry.id}`
-            ? entry.name
-            : `${entry.name} (${entry.provider}/${entry.id})`,
-        reasoning: entry.reasoning,
-      })),
+      models.map((entry) => {
+        const key = `${entry.provider}/${entry.id}`;
+        const alias = typeof entry.name === "string" ? entry.name.trim() : "";
+        return {
+          value: key,
+          label: !alias || alias === key ? key : alias,
+          reasoning: entry.reasoning,
+        };
+      }),
     [models]
   );
   const modelValue = agent.model ?? "";


### PR DESCRIPTION
Summary
- update the agent model dropdown to use configured aliases when they exist and fall back to the provider/id key when not
- trim alias values before comparing so empty strings don’t override the fallback label

Testing
- Not run (not requested)