### PR TITLE
Thinking traces: preserve line breaks

### DIFF
--- a/src/lib/text/message-extract.ts
+++ b/src/lib/text/message-extract.ts
@@ -305,7 +305,7 @@ export const formatThinkingMarkdown = (text: string): string => {
     .filter(Boolean)
     .map((line) => `_${line}_`);
   if (lines.length === 0) return "";
-  return `${TRACE_MARKDOWN_PREFIX}\n${lines.join("\n")}`;
+  return `${TRACE_MARKDOWN_PREFIX}\n${lines.join("\n\n")}`;
 };
 
 export const isTraceMarkdown = (line: string): boolean =>

--- a/tests/unit/createAgentOperation.test.ts
+++ b/tests/unit/createAgentOperation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayClient } from "@/lib/gateway/GatewayClient";
 import {
   compileGuidedAgentCreation,
@@ -46,6 +46,18 @@ const createSetupFromBundle = (bundle: AgentPresetBundle): AgentGuidedSetup => {
 };
 
 describe("createAgentOperation", () => {
+  beforeEach(() => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: vi.fn(async () => JSON.stringify({ keys: [] })),
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("applies guided setup for local gateway creation", async () => {
     const setup = createSetup();
     const client = {

--- a/tests/unit/extractThinking.test.ts
+++ b/tests/unit/extractThinking.test.ts
@@ -96,7 +96,7 @@ describe("formatThinkingMarkdown", () => {
     const input = "Line 1\n\n  Line 2  ";
     const formatted = formatThinkingMarkdown(input);
     expect(isTraceMarkdown(formatted)).toBe(true);
-    expect(stripTraceMarkdown(formatted)).toBe("_Line 1_\n_Line 2_");
+    expect(stripTraceMarkdown(formatted)).toBe("_Line 1_\n\n_Line 2_");
   });
 });
 


### PR DESCRIPTION
- Render thinking trace lines as separate paragraphs (prevents markdown collapsing them into one).\n- Update thinking formatting unit test.\n- Stabilize createAgentOperation unit tests by stubbing dotenv-keys fetch to avoid environment-dependent network behavior.