### PR TITLE
Fix duplicate user message caused by injected approval policy

### DIFF
--- a/src/lib/text/message-extract.ts
+++ b/src/lib/text/message-extract.ts
@@ -41,6 +41,12 @@ const EXEC_APPROVAL_WAIT_POLICY = [
   'If approved command output is unavailable, reply exactly: "Waiting for approved command result."',
 ].join("\n");
 
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const EXEC_APPROVAL_WAIT_POLICY_SUFFIX_RE = new RegExp(
+  `(?:\\r?\\n){2}${escapeRegExp(EXEC_APPROVAL_WAIT_POLICY).replace(/\n/g, "\\r?\\n")}\\s*$`
+);
+
 type ToolCallRecord = {
   id?: string;
   name?: string;
@@ -515,6 +521,7 @@ export const stripUiMetadata = (text: string) => {
     cleaned = cleaned.replace(PROJECT_PROMPT_BLOCK_RE, "");
   }
   cleaned = cleaned.replace(MESSAGE_ID_RE, "").trim();
+  cleaned = cleaned.replace(EXEC_APPROVAL_WAIT_POLICY_SUFFIX_RE, "").trim();
   return cleaned;
 };
 

--- a/tests/unit/messageExtract.test.ts
+++ b/tests/unit/messageExtract.test.ts
@@ -87,8 +87,7 @@ describe("message-extract", () => {
     });
 
     expect(isUiMetadataPrefix(built)).toBe(false);
-    expect(stripUiMetadata(built)).toContain("hello");
-    expect(stripUiMetadata(built)).toContain("Execution approval policy:");
+    expect(stripUiMetadata(built)).toBe("hello");
   });
 
   it("strips leading system event blocks from queued session updates", () => {


### PR DESCRIPTION
## Summary
-

## Testing
- [ ] Not run (explain why)
- [ ] `npm run lint`
- [ ] `npm run typecheck`
- [ ] `npm run test`
- [ ] `npm run e2e`

## AI-assisted
- [ ] AI-assisted (briefly describe what and include prompts/logs if helpful)
