### PR TITLE
Fix Studio message pollution + sandbox exec approvals

### DIFF
--- a/tests/unit/messageExtract.test.ts
+++ b/tests/unit/messageExtract.test.ts
@@ -88,7 +88,7 @@ describe("message-extract", () => {
 
     expect(isUiMetadataPrefix(built)).toBe(false);
     expect(stripUiMetadata(built)).toContain("hello");
-    expect(stripUiMetadata(built)).toContain("Execution approval policy:");
+    expect(stripUiMetadata(built)).not.toContain("Execution approval policy:");
   });
 
   it("strips leading system event blocks from queued session updates", () => {

--- a/tests/unit/messageHelpers.test.ts
+++ b/tests/unit/messageHelpers.test.ts
@@ -3,12 +3,11 @@ import { describe, expect, it } from "vitest";
 import { buildAgentInstruction } from "@/lib/text/message-extract";
 
 describe("buildAgentInstruction", () => {
-  it("returns trimmed message with approval wait policy for normal prompts", () => {
+  it("returns trimmed message for normal prompts", () => {
     const message = buildAgentInstruction({
       message: " Ship it ",
     });
-    expect(message.startsWith("Ship it\n\nExecution approval policy:")).toBe(true);
-    expect(message).toContain('reply exactly: "Waiting for approved command result."');
+    expect(message).toBe("Ship it");
   });
 
   it("returns command messages untouched", () => {

--- a/tests/unit/worktreeHelpers.test.ts
+++ b/tests/unit/worktreeHelpers.test.ts
@@ -3,11 +3,11 @@ import { describe, expect, it } from "vitest";
 import { buildAgentInstruction } from "@/lib/text/message-extract";
 
 describe("buildAgentInstruction", () => {
-  it("returns plain message text with approval wait policy", () => {
+  it("returns trimmed message text", () => {
     const message = buildAgentInstruction({
       message: "Ship it",
     });
 
-    expect(message.startsWith("Ship it\n\nExecution approval policy:")).toBe(true);
+    expect(message).toBe("Ship it");
   });
 });


### PR DESCRIPTION
### Problem
- User messages were being mutated with an appended "Execution approval policy" block.
- Assistant replies could leak a `[reply_to_current]` prefix and timestamp envelopes into the UI.
- Sandbox agents (sandbox.mode=all) could end up with session execHost defaulting to gateway, leading to missing exec approvals / no exec tool calls.
- Switching execution role in the sidebar updated config/approvals but did not patch the active session settings.

### Changes
- Stop appending the approval policy to outgoing user messages and strip any previously-appended policy suffix for display.
- Strip `[reply_to_current]` and support `[Fri 2026-.. UTC]` envelope headers in display normalization.
- Default session execHost to `sandbox` for agents configured with sandbox.mode=all.
- When updating execution role, also patch the agent main session settings (execHost/execSecurity/execAsk) so it takes effect immediately.

### Test Plan
- `npm test`
- In Studio: create agent with System Access = Ask first, run `ls -laht`, verify approval card appears and execution proceeds after approval.
- Switch to Autonomous, run `ls -laht` again, verify it executes without an approval prompt.