### PR TITLE
Fix sandboxed agents stuck thinking (sandbox tool allowlist)

### DIFF
--- a/src/features/agents/creation/compiler.ts
+++ b/src/features/agents/creation/compiler.ts
@@ -549,11 +549,6 @@ export const compileGuidedAgentCreation = (params: {
         profile: params.draft.controls.toolsProfile,
         alsoAllow: normalizedAlsoAllow,
         deny: normalizedDeny,
-        sandbox: {
-          tools: {
-            allow: [],
-          },
-        },
       },
     },
     execApprovals: params.draft.controls.allowExec

--- a/src/features/agents/operations/agentFleetHydrationDerivation.ts
+++ b/src/features/agents/operations/agentFleetHydrationDerivation.ts
@@ -221,13 +221,13 @@ export const deriveHydrateAgentFleetResult = (
     const sandboxMode = resolveAgentSandboxMode(agent.id, input.configSnapshot);
     const resolvedExecSecurity = sessionExecSecurity ?? policy?.security;
     const resolvedExecAsk = sessionExecAsk ?? policy?.ask;
-    const resolvedExecHost =
-      sessionExecHost ??
-      (resolvedExecSecurity || resolvedExecAsk
-        ? sandboxMode === "all"
-          ? "sandbox"
-          : "gateway"
-        : undefined);
+    const shouldForceSandboxExecHost =
+      sandboxMode === "all" &&
+      Boolean(sessionExecHost || resolvedExecSecurity || resolvedExecAsk);
+    const resolvedExecHost = shouldForceSandboxExecHost
+      ? "sandbox"
+      : sessionExecHost ??
+        (resolvedExecSecurity || resolvedExecAsk ? "gateway" : undefined);
     const expectsExecOverrides = Boolean(
       resolvedExecHost || resolvedExecSecurity || resolvedExecAsk
     );

--- a/src/features/agents/operations/useConfigMutationQueue.ts
+++ b/src/features/agents/operations/useConfigMutationQueue.ts
@@ -8,7 +8,8 @@ export type ConfigMutationKind =
   | "create-agent"
   | "rename-agent"
   | "delete-agent"
-  | "update-agent-execution-role";
+  | "update-agent-execution-role"
+  | "repair-sandbox-tool-allowlist";
 
 type QueuedConfigMutation = {
   id: string;

--- a/src/lib/text/message-extract.ts
+++ b/src/lib/text/message-extract.ts
@@ -50,6 +50,7 @@ const stripAppendedExecApprovalPolicy = (text: string): string => {
 const ASSISTANT_PREFIX_RE = /^\[reply_to_current\]\s*(?:\|\s*)?/i;
 const stripAssistantPrefix = (text: string): string => {
   if (!text) return text;
+  if (!ASSISTANT_PREFIX_RE.test(text)) return text;
   return text.replace(ASSISTANT_PREFIX_RE, "").trimStart();
 };
 


### PR DESCRIPTION
### What
New sandboxed agents created in Studio could get `tools.sandbox.tools.allow: []` in `openclaw.json`. In practice this is interpreted as an explicit allowlist with zero entries, so *no tools are available in the sandbox*.

That matches your logs:
- Session is sandboxed (`sandbox.mode=all`)
- System prompt report shows `tools.entries: []`
- Model says it will use `exec`, but cannot actually call tools, so you only see the thinking block and no output/approval.

### Fix
- Stop writing `tools.sandbox.tools.allow: []` during agent creation (omit the override).
- Add a one-time auto-repair on connect: if an agent is sandboxed and has an empty sandbox allowlist, Studio patches it to `allow: ["*"]` and reloads agents.
- Force `execHost` to `sandbox` in derived session settings for sandbox.mode=all so Studio will patch sessions that are incorrectly on `gateway`.
- Avoid trimming assistant text unless `[reply_to_current]` prefix was actually removed.

### Test Plan
- `npm test`
- Create a new agent (Collaborative / Ask first), send `ls -laht`, verify an exec approval appears and execution proceeds after approval.