### PR TITLE
Refactor execution role and latest update helpers

### DIFF
--- a/.agent/done/2026-02-15-extract-execution-role-update-operation.md
+++ b/.agent/done/2026-02-15-extract-execution-role-update-operation.md
@@ -1,0 +1,200 @@
+# Extract Execution Role Update Flow From `src/app/page.tsx`
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+This repository’s ExecPlan format is defined in `.agent/PLANS.md`, and this document must be maintained in accordance with it.
+
+## Purpose / Big Picture
+
+Today, changing an agent’s “Execution role” from the settings sidebar is implemented inline inside the main page component (`src/app/page.tsx`). That single flow mixes domain decisions (how each role maps to exec approvals policy, session exec settings, and tool allow/deny rules) with infrastructure side effects (gateway reads/writes and page-level `loadAgents()` refresh) inside one long `enqueueConfigMutation` callback.
+
+After this refactor, the execution-role update flow will live in a dedicated operation module with a small, explicit interface and unit tests for the role-mapping and tool-override derivation. `src/app/page.tsx` will become wiring: it will enqueue the mutation and call the operation. There must be no user-visible behavior change.
+
+## Progress
+
+- [x] Create an execution-role update operation module with pure, unit-testable derivation helpers.
+- [x] Rewire `src/app/page.tsx` to call the new operation and delete the inlined flow.
+- [x] Add unit tests covering role-to-policy mapping and tool allow/deny patch derivation (including `allow` vs `alsoAllow` semantics).
+- [x] Run `npm run typecheck` and `npm test`.
+
+## Surprises & Discoveries
+
+- `src/app/page.tsx` had enough local edits since the plan was drafted that a naive patch failed; patching against the exact `handleUpdateExecutionRole` block worked cleanly.
+
+## Decision Log
+
+- Decision: Extract the execution-role update flow out of `src/app/page.tsx` into a dedicated operation module.
+  Rationale: This is a cohesive “god flow” chunk that interleaves gateway I/O (`exec.approvals.*`, `config.get`, `config.patch` via `updateGatewayAgentOverrides`, `sessions.patch` via `syncGatewaySessionSettings`) with domain rules (role mapping and tool allowlist semantics). Extracting it makes the domain rules testable without React/page wiring and reduces churn risk in a 2800+ line page component.
+  Date/Author: 2026-02-15 / Codex
+
+## Outcomes & Retrospective
+
+- Extracted execution-role update flow into `src/features/agents/operations/executionRoleUpdateOperation.ts`.
+- Rewired `src/app/page.tsx` to call `updateExecutionRoleViaStudio(...)` and removed the inline role/policy/tool/session derivation logic.
+- Added unit coverage in `tests/unit/executionRoleUpdateOperation.test.ts` for policy mapping, `allow` vs `alsoAllow` semantics, tool allow/deny derivation, and session exec settings.
+- Verified `npm run typecheck` and `npm test` pass. (2026-02-15)
+
+## Context and Orientation
+
+“Execution role” is a UI-level setting shown in the agent settings sidebar. The selector lives in `src/features/agents/components/AgentInspectPanels.tsx` and calls a callback prop `onUpdateExecutionRole(role)` when the user clicks “Update”.
+
+The current end-to-end execution-role update flow is implemented in the main page:
+
+- `handleUpdateExecutionRole` in `src/app/page.tsx:2170` through `src/app/page.tsx:2311`.
+
+Key gateway helpers involved (and where they live):
+
+- Exec approvals read/write:
+  - `readGatewayAgentExecApprovals` and `upsertGatewayAgentExecApprovals` in `src/lib/gateway/execApprovals.ts`
+  - Allowlist entries are shaped like `Array<{ pattern: string }>` (not string arrays).
+- Config list parsing and tool overrides write:
+  - `readConfigAgentList` and `updateGatewayAgentOverrides` in `src/lib/gateway/agentConfig.ts`
+- Session exec settings write:
+  - `syncGatewaySessionSettings` in `src/lib/gateway/GatewayClient.ts`
+
+In that block, the flow:
+
+1. Reads the agent’s existing exec approvals policy via `readGatewayAgentExecApprovals`.
+2. Builds and writes a new per-agent exec approvals policy via `upsertGatewayAgentExecApprovals`.
+3. Reads gateway config via `client.call("config.get", {})`, parses `agents.list`, finds the agent’s config entry, and reads `sandbox.mode` and `tools` allow/deny state.
+4. Mutates the agent’s gateway config overrides via `updateGatewayAgentOverrides`, specifically manipulating tool allow/deny lists to add/remove `group:runtime` depending on role.
+5. Computes session exec settings (`execHost`, `execSecurity`, `execAsk`) based on role and sandbox mode, and writes them via `syncGatewaySessionSettings`.
+6. Reloads agents via `loadAgents()` to reflect the change.
+
+This is the entanglement: the role-mapping and tool-override rules are domain logic, but they are embedded directly inside the infrastructure call stack and React wiring.
+
+## Plan of Work
+
+Extract the flow into a new operation module that has:
+
+1. A single side-effecting entry point that performs the gateway calls in the same order as today.
+2. A small set of pure helper functions (in the same file) that compute:
+   - The next exec approvals policy for a given role, preserving allowlist.
+   - The next tool override patch (`allow` vs `alsoAllow`, plus `deny`) for a given role and existing tools config.
+   - The next session exec settings (`execHost`, `execSecurity`, `execAsk`) for a given role and sandbox mode.
+
+Then rewire `src/app/page.tsx` to call the new operation from inside the existing `enqueueConfigMutation` wrapper.
+
+## Concrete Steps
+
+1. Create `src/features/agents/operations/executionRoleUpdateOperation.ts`.
+
+   In this file, implement:
+
+   - Imports (use existing module boundaries; do not duplicate gateway helpers):
+     - `import type { GatewayClient } from "@/lib/gateway/GatewayClient";`
+     - `import { syncGatewaySessionSettings } from "@/lib/gateway/GatewayClient";`
+     - `import { readGatewayAgentExecApprovals, upsertGatewayAgentExecApprovals } from "@/lib/gateway/execApprovals";`
+     - `import { readConfigAgentList, updateGatewayAgentOverrides } from "@/lib/gateway/agentConfig";`
+
+   - `export type ExecutionRoleId = "conservative" | "collaborative" | "autonomous";`
+
+   - Pure helpers (export them so tests can import them):
+
+     - `export function resolveExecApprovalsPolicyForRole(params: { role: ExecutionRoleId; allowlist: Array<{ pattern: string }> }): null | { security: "full" | "allowlist"; ask: "off" | "always"; allowlist: Array<{ pattern: string }> }`
+       Behavior must match the current `nextPolicy` logic in `src/app/page.tsx:2194` through `src/app/page.tsx:2207`. Note: in this repo, the allowlist is stored as objects shaped like `{ pattern: string }` (see `src/lib/gateway/execApprovals.ts`), not raw strings.
+
+     - `export function resolveRuntimeToolOverridesForRole(params: { role: ExecutionRoleId; existingTools: unknown }): { tools: { allow?: string[]; alsoAllow?: string[]; deny?: string[] } }`
+       Behavior must match the current tool override logic in `src/app/page.tsx:2233` through `src/app/page.tsx:2274`, including:
+       - If `existingTools.allow` is an array (even empty), treat it as the primary allowlist (`usesAllow = true`) and write back to `allow`.
+       - Otherwise, treat `existingTools.alsoAllow` as the primary allowlist (`usesAllow = false`) and write back to `alsoAllow`.
+       - Always trim strings and drop empties.
+       - Add or remove `group:runtime` based on role.
+       - Ensure `deny` does not contain entries that are present in the chosen allow list.
+
+     - `export function resolveSessionExecSettingsForRole(params: { role: ExecutionRoleId; sandboxMode: string }): { execHost: "sandbox" | "gateway" | null; execSecurity: "deny" | "allowlist" | "full"; execAsk: "off" | "always" }`
+       Behavior must match `src/app/page.tsx:2276` through `src/app/page.tsx:2296`, including the sandbox host selection when sandbox mode is `"all"`.
+
+   - Side-effecting operation:
+
+     - `export async function updateExecutionRoleViaStudio(params: { client: GatewayClient; agentId: string; sessionKey: string; role: ExecutionRoleId; loadAgents: () => Promise<void> }): Promise<void>`
+
+       It should:
+       - Read allowlist: `readGatewayAgentExecApprovals({ client, agentId })`.
+       - Compute `nextPolicy` using `resolveExecApprovalsPolicyForRole` and write it with `upsertGatewayAgentExecApprovals`. The allowlist passed through must be `Array<{ pattern: string }>` and must be preserved exactly (it is already normalized by `readGatewayAgentExecApprovals`).
+       - Read config: `client.call("config.get", {})`, parse list using the existing `readConfigAgentList` helper, find entry for `agentId`, and extract `sandbox.mode` and `tools` object.
+         - Preserve the current page’s normalization behavior exactly:
+           - `sandboxMode` must be computed as `typeof sandbox?.mode === "string" ? sandbox.mode.trim().toLowerCase() : ""`.
+           - `existingTools` must be treated as `null` unless it is a plain object (`typeof === "object"`, not array).
+       - Compute tool overrides with `resolveRuntimeToolOverridesForRole` and apply using `updateGatewayAgentOverrides`.
+       - Compute session settings with `resolveSessionExecSettingsForRole` and apply using `syncGatewaySessionSettings`.
+       - Call `loadAgents()` at the end.
+
+       Keep error behavior the same as current page flow (exceptions should bubble up to the existing mutation wrapper).
+
+2. Rewire `src/app/page.tsx` and delete the inlined logic.
+
+   In `src/app/page.tsx`, change `handleUpdateExecutionRole` (currently `src/app/page.tsx:2170` through `src/app/page.tsx:2311`) to:
+
+   - Keep the same outer guards (`resolveMutationStartGuard`, agent lookup, and `enqueueConfigMutation` call).
+   - Replace the entire `run: async () => { ... }` body with a call to `updateExecutionRoleViaStudio({ client, agentId: resolvedAgentId, sessionKey: agent.sessionKey, role, loadAgents })`.
+   - Remove now-unused imports from `src/app/page.tsx`:
+     - Always expected: `readGatewayAgentExecApprovals` and `upsertGatewayAgentExecApprovals` (they are only used by this flow today).
+     - Possibly expected: `syncGatewaySessionSettings` (currently only used by this flow; confirm with `rg -n "syncGatewaySessionSettings\\b" src/app/page.tsx` after rewiring).
+     - Do not remove `readConfigAgentList` or `updateGatewayAgentOverrides` unless you confirm they are unused; they are referenced elsewhere in `src/app/page.tsx` (for example the sandbox-tool repair flow).
+   - Keep the `enqueueConfigMutation` label string the same.
+
+   Acceptance check for this step: `src/app/page.tsx` should no longer contain the `coerceStringArray` helper or any manipulation of `group:runtime` in tool lists.
+
+3. Add unit tests in `tests/unit/executionRoleUpdateOperation.test.ts`.
+
+   Write tests that validate the pure derivations without needing to mock gateway calls:
+
+   - `it("maps roles to exec approvals policy while preserving allowlist")`
+     - Provide `allowlist = [{ pattern: "a" }, { pattern: "b" }]`.
+     - Assert conservative returns `null`.
+     - Assert collaborative returns `{ security: "allowlist", ask: "always", allowlist }`.
+     - Assert autonomous returns `{ security: "full", ask: "off", allowlist }`.
+
+     - `it("updates tool overrides using allow when existing tools.allow is present")`
+       - Input `existingTools = { allow: ["group:web"], deny: ["group:runtime"] }`.
+       - For collaborative/autonomous, assert output uses `allow` (not `alsoAllow`), `allow` contains `group:runtime`, and `deny` does not contain `group:runtime`.
+       - For conservative, assert `allow` does not contain `group:runtime` and `deny` contains `group:runtime`.
+
+     - `it("updates tool overrides using alsoAllow when tools.allow is absent")`
+       - Input `existingTools = { alsoAllow: ["group:web"], deny: [] }`.
+       - Assert output writes to `alsoAllow` and applies the same `group:runtime` semantics.
+
+     - `it("resolves session exec settings from role and sandbox mode")`
+       - For conservative, expect `{ execHost: null, execSecurity: "deny", execAsk: "off" }`.
+       - For collaborative/autonomous with `sandboxMode = "all"`, expect `execHost: "sandbox"`.
+       - For collaborative/autonomous with any other sandbox mode (for example `"none"`), expect `execHost: "gateway"`.
+
+     - Optional edge-case test (recommended because it mirrors the page’s current defaults):
+       - `it("treats missing tools config as empty lists and still enforces group:runtime semantics")`
+         - Input `existingTools = null` (or `undefined`).
+         - Assert collaborative/autonomous returns `alsoAllow` containing `group:runtime` (since `allow` is not present, `usesAllow = false`).
+
+4. Run validation commands from the repo root (`/Users/georgepickett/.codex/worktrees/f6bd/openclaw-studio`):
+
+   - `npm run typecheck`
+   - `npm test`
+
+## Validation and Acceptance
+
+This refactor is accepted when all items below are true:
+
+1. The execution-role update flow no longer lives inline in `src/app/page.tsx` and is instead implemented in `src/features/agents/operations/executionRoleUpdateOperation.ts`.
+2. `src/app/page.tsx` no longer contains the tool allow/deny manipulation logic for `group:runtime` (the `coerceStringArray` block is removed).
+3. `tests/unit/executionRoleUpdateOperation.test.ts` exists and passes, and it covers:
+   - role to exec approvals mapping
+   - `allow` vs `alsoAllow` tool override semantics
+   - session exec setting resolution from role + sandbox mode
+4. `npm run typecheck` and `npm test` succeed.
+
+## Idempotence and Recovery
+
+This is an additive refactor (new module + rewiring) and is safe to retry:
+
+- If partial changes break compilation, revert with `git checkout -- src/app/page.tsx` and delete the new files.
+- No migrations, no deletes of runtime data, and no changes to gateway protocols are required.
+
+## Artifacts and Notes
+
+Revision note (2026-02-15): Improved this ExecPlan by grounding it against the actual code in `src/app/page.tsx:2170` and the gateway helper modules. Corrections and additions:
+
+- Fixed allowlist typing to match `src/lib/gateway/execApprovals.ts` (`Array<{ pattern: string }>`), and updated the tests accordingly.
+- Updated the side-effecting operation signature to take `GatewayClient` (from `src/lib/gateway/GatewayClient.ts`) so the implementation can call the existing gateway helpers without casts.
+- Tightened the rewiring step to only remove imports that become unused after extraction (specifically not removing `readConfigAgentList` / `updateGatewayAgentOverrides`, which are used elsewhere in `src/app/page.tsx`).
+- Added explicit notes about preserving the page’s current normalization behavior for `sandboxMode` and for treating `tools` as `null` unless it is a plain object.
+- Added an optional edge-case test that mirrors the current “missing tools config” behavior.

--- a/.agent/done/2026-02-15-extract-special-latest-update-operation.md
+++ b/.agent/done/2026-02-15-extract-special-latest-update-operation.md
@@ -1,0 +1,217 @@
+# Extract Special Latest Update Refresh From `src/app/page.tsx`
+
+This ExecPlan is a living document. The sections `Progress`, `Surprises & Discoveries`, `Decision Log`, and `Outcomes & Retrospective` must be kept up to date as work proceeds.
+
+This repository’s ExecPlan format is defined in `.agent/PLANS.md`, and this document must be maintained in accordance with it.
+
+## Purpose / Big Picture
+
+Today, `src/app/page.tsx` contains the “special latest update” refresh flow that decides when an agent’s fleet-row `latestOverride` should be replaced by a derived “Heartbeat” or “Cron” preview, and it performs the required gateway calls (`sessions.list`, `chat.history`, `cron.list`) inline. This mixes domain policy (how to interpret “heartbeat” vs “cron”, how to choose the “heartbeat session”, what to display) with infrastructure side effects (gateway I/O, dispatching patches) inside a 2956-line page component.
+
+After this refactor, the special latest update refresh flow will live in a dedicated operation module with an explicit interface and unit tests. `src/app/page.tsx` will become wiring: it will construct the updater with dependencies and call it, without embedding the gateway-response parsing and derivation logic in the page component. There must be no user-visible behavior change.
+
+## Progress
+
+- [x] (2026-02-15 19:43Z) Create `src/features/agents/operations/specialLatestUpdateOperation.ts` with `createSpecialLatestUpdateOperation` (`update`, `refreshHeartbeat`, `clearInFlight`).
+- [x] (2026-02-15 19:43Z) Rewire `src/app/page.tsx` to use the extracted operation; remove the inlined special-latest-update logic and in-flight ref.
+- [x] (2026-02-15 19:43Z) Add `tests/unit/specialLatestUpdateOperation.test.ts` covering reset, heartbeat selection/history parsing, cron formatting, and in-flight dedupe.
+- [x] (2026-02-15 19:43Z) Validate with `npm run typecheck` and `npm test` (all tests passing).
+
+## Surprises & Discoveries
+
+- `npm run typecheck` initially failed because `tsc` was not available (dependencies not installed). Running `npm ci` installed `node_modules` and unblocked typecheck + tests.
+
+## Decision Log
+
+- Decision: Extract the “special latest update” refresh flow (heartbeat + cron) out of `src/app/page.tsx` into a dedicated operation module.
+  Rationale: It is a cohesive, high-leverage seam already injected into the runtime event handler (`createGatewayRuntimeEventHandler` deps). It currently mixes domain derivation and gateway I/O inside the page; extracting it reduces the page’s god-flow surface area and makes the derivation testable without mounting the full page component.
+  Date/Author: 2026-02-15 / Codex
+
+## Outcomes & Retrospective
+
+- Extracted the special latest-update refresh flow into a dedicated operation module and added focused unit tests for it. `src/app/page.tsx` is now wiring for this flow (delegates to the operation), reducing page-level infrastructure/domain interleaving while keeping behavior stable.
+
+## Context and Orientation
+
+Definitions (in this repo’s terms):
+
+“Gateway”: the upstream OpenClaw Gateway that Studio talks to over WebSocket via `GatewayClient.call(method, params)`.
+
+“Special latest update”: the behavior that, when a user’s last message contains the word “heartbeat” or “cron”, overrides the agent’s `latestPreview` display in the fleet list using derived content. The override is stored in `AgentState.latestOverride` and `AgentState.latestOverrideKind` (see `src/features/agents/state/store.tsx`).
+
+Key files and the exact code we are extracting from:
+
+- `src/app/page.tsx` (2956 lines): main Studio page “god flow”. It owns gateway connection wiring, fleet hydration, pending guided setup retry, exec approvals lifecycle, cron/heartbeat settings loaders, and also special latest-update refresh.
+- `src/features/agents/operations/latestUpdateWorkflow.ts`: pure policy for identifying “latest update” kind and intent (`resolveLatestUpdateIntent`) and for producing `latestOverride` patches (`buildLatestUpdatePatch`).
+- `src/features/agents/state/gatewayRuntimeEventHandler.ts`: runtime event handler which depends on `updateSpecialLatestUpdate` and `refreshHeartbeatLatestUpdate` (injected from `src/app/page.tsx`).
+
+The entangled flow we are extracting lives in `src/app/page.tsx`:
+
+- `findLatestHeartbeatResponse` at `src/app/page.tsx:213`.
+- `updateSpecialLatestUpdate` at `src/app/page.tsx:585`.
+- `refreshHeartbeatLatestUpdate` at `src/app/page.tsx:664`.
+- The “scan agents and enqueue updates” effect at `src/app/page.tsx:1225` which calls `updateSpecialLatestUpdate` for each agent.
+- Runtime event wiring injects this function into the handler at `src/app/page.tsx:2082` and the handler invokes it for `queueLatestUpdate` intents at `src/features/agents/state/gatewayRuntimeEventHandler.ts:331`.
+
+There is one additional page-level coupling that must keep working after extraction: starting a new session explicitly clears the in-flight tracker for this flow at `src/app/page.tsx:1820` by calling `specialUpdateInFlightRef.current.delete(agentId)`. After extraction we need an equivalent “clear in-flight for agent” call so new sessions do not get stuck behind a stale in-flight key.
+
+What makes this architectural entanglement (not a single impure function):
+
+- Domain rules (what counts as a “heartbeat session”, how to extract the heartbeat result, how to format the cron latest-update display, when to reset overrides) are embedded inside a React page component and interleaved with gateway I/O and `dispatch` calls.
+- Testing the domain behavior today requires mounting `src/app/page.tsx` or re-implementing the logic in tests, because there is no boundary module to call with plain inputs.
+
+## Plan of Work
+
+Create a new module, `src/features/agents/operations/specialLatestUpdateOperation.ts`, that owns the extracted flow. This module will be a plain TypeScript module (no React hooks) and will be constructed with explicit dependencies (gateway call function, cron listing, dispatch patch callback, logging). It will return an updater with three responsibilities:
+
+1. `update(agentId, agent, message)`: replicate the current `updateSpecialLatestUpdate` behavior exactly, including intent resolution, heartbeat-session selection, history parsing, cron selection, and patch dispatch.
+2. `refreshHeartbeat(agents)`: replicate the current “force refresh heartbeat” loop.
+3. `clearInFlight(agentId)`: replace the one existing usage of `specialUpdateInFlightRef.current.delete(agentId)` in `handleNewSession` so the in-flight guard stays correct.
+
+Then, update `src/app/page.tsx` to delete the embedded functions and wire the new updater instead.
+
+Finally, add unit tests for the new module to prove behavior without rendering the page.
+
+## Concrete Steps
+
+1. Create the new operation module at `src/features/agents/operations/specialLatestUpdateOperation.ts`.
+
+   In this file, implement a factory function (name it exactly as below) that closes over an in-flight `Set<string>` and exposes three functions:
+
+   `export function createSpecialLatestUpdateOperation(deps: SpecialLatestUpdateDeps): SpecialLatestUpdateOperation`
+
+   The concrete behavior must be lifted from the existing implementation in `src/app/page.tsx:585` (do not reinterpret it). Keep the same intent resolution and patch shapes by importing and using:
+
+   - `resolveLatestUpdateIntent` and `buildLatestUpdatePatch` from `src/features/agents/operations/latestUpdateWorkflow.ts`
+   - `resolveLatestUpdateKind` remains in the page (used for the scan marker), but the operation should not need it.
+
+   The operation needs these dependencies (all explicit so tests can stub them):
+
+   - `callGateway(method: string, params: unknown): Promise<unknown>`; this will be `client.call.bind(client)` at the call site.
+   - `listCronJobs(): Promise<{ jobs: CronJobSummary[] }>`; the page can provide `() => listCronJobs(client, { includeDisabled: true })` to preserve the current `includeDisabled` behavior.
+   - `resolveCronJobForAgent(jobs: CronJobSummary[], agentId: string): CronJobSummary | null`; the page already has this callback around `resolveLatestCronJobForAgent`.
+   - `formatCronJobDisplay(job: CronJobSummary): string`; use the existing function from `src/lib/cron/types.ts`.
+   - `dispatchUpdateAgent(agentId: string, patch: { latestOverride: string | null; latestOverrideKind: "heartbeat" | "cron" | null }): void`; the page will implement this by dispatching `{ type: "updateAgent", ... }`.
+   - `isDisconnectLikeError(err: unknown): boolean`; use the existing `isGatewayDisconnectLikeError`.
+   - `logError(message: string): void`; default call site should use `console.error(message)`.
+
+   The operation must accept an `agent` value as an `AgentState` (type-only import from `src/features/agents/state/store.tsx`) because the current function reads `agent.agentId`, `agent.sessionKey`, and checks whether an override exists via `agent.latestOverride` / `agent.latestOverrideKind`.
+
+   Implement a helper inside the module that is moved from the page:
+
+   - `findLatestHeartbeatResponse(messages: Array<Record<string, unknown>>): string | null` (lift `src/app/page.tsx:213`). This helper must keep using `extractText`, `stripUiMetadata`, and `isHeartbeatPrompt` from `src/lib/text/message-extract.ts` so that it stays aligned with how Studio interprets heartbeat prompts elsewhere.
+
+   Implement `operation.update(agentId, agent, message)` with the same behavior as the page:
+
+   - Resolve intent using `resolveLatestUpdateIntent({ message, agentId: agent.agentId, sessionKey: agent.sessionKey, hasExistingOverride: Boolean(agent.latestOverride || agent.latestOverrideKind) })`.
+   - If intent is `noop`, return without dispatch.
+   - If intent is `reset`, call `dispatchUpdateAgent(agent.agentId, buildLatestUpdatePatch(""))` and return.
+   - Enforce the same per-agent in-flight guard that exists today (the `Set` is keyed by the `agentId` argument, matching the current code).
+   - Heartbeat path:
+     - Call `callGateway("sessions.list", { agentId: intent.agentId, includeGlobal: false, includeUnknown: false, limit: intent.sessionLimit })` and treat the result shape the same way the page does (if `sessions.sessions` is not an array, treat it as `[]`).
+     - Filter entries where `entry.origin?.label` exists and is `"heartbeat"` case-insensitive, else fall back to the whole list. Sort descending by `updatedAt ?? 0`.
+     - If there is no `sessionKey`, dispatch a reset patch (same as the page does) and return.
+     - Call `callGateway("chat.history", { sessionKey, limit: intent.historyLimit })` and pass `history.messages ?? []` into `findLatestHeartbeatResponse`.
+     - Dispatch `buildLatestUpdatePatch(content, "heartbeat")`.
+   - Cron path:
+     - Call `listCronJobs()`, resolve the job for `intent.agentId`, build `content` using `formatCronJobDisplay(job)` (or empty string), and dispatch `buildLatestUpdatePatch(content, "cron")`.
+   - In all cases, remove the `agentId` key from the in-flight set in a `finally` block, matching the page’s behavior.
+   - Preserve the current logging behavior: on exceptions, if `!isDisconnectLikeError(err)`, log the same message the page uses today (“Failed to load latest cron/heartbeat update.”) and do not throw.
+
+   Implement `operation.refreshHeartbeat(agents)` to loop over the passed array and call `void operation.update(agent.agentId, agent, "heartbeat")`, matching `src/app/page.tsx:664`.
+
+   Implement `operation.clearInFlight(agentId)` to delete the given key from the in-flight set. This is required because `src/app/page.tsx:1837` currently clears the ref directly.
+
+2. Wire the operation into `src/app/page.tsx` and remove the extracted code.
+
+   - Remove `findLatestHeartbeatResponse` (currently at `src/app/page.tsx:213`).
+   - Remove `specialUpdateInFlightRef` (currently at `src/app/page.tsx:321`).
+   - Remove `updateSpecialLatestUpdate` and `refreshHeartbeatLatestUpdate` (currently at `src/app/page.tsx:585` and `src/app/page.tsx:664`).
+   - Add an import for the new factory from `src/features/agents/operations/specialLatestUpdateOperation.ts`.
+   - Construct the operation once per page instance using `useMemo` so the in-flight set is stable:
+
+     - Its `callGateway` should be `(method, params) => client.call(method, params)`.
+     - Its `listCronJobs` should be `() => listCronJobs(client, { includeDisabled: true })` (this preserves the current behavior).
+     - Its `dispatchUpdateAgent` should call the existing `dispatch({ type: "updateAgent", agentId, patch })`.
+
+   - Update the “scan agents and enqueue updates” effect at `src/app/page.tsx:1225` to call `void specialLatestUpdate.update(agent.agentId, agent, lastMessage)` instead of the removed callback.
+
+   - Update the runtime handler wiring at `src/app/page.tsx:2082`:
+
+     - Replace `refreshHeartbeatLatestUpdate` with a wrapper that calls `specialLatestUpdate.refreshHeartbeat(stateRef.current.agents)`.
+     - Replace `updateSpecialLatestUpdate` with `specialLatestUpdate.update`.
+
+   - Update `handleNewSession` at `src/app/page.tsx:1820`:
+
+     - Replace `specialUpdateInFlightRef.current.delete(agentId)` with `specialLatestUpdate.clearInFlight(agentId)`.
+     - Keep `specialUpdateRef.current.delete(agentId)` as-is (this is a separate “marker seen” cache and should stay in the page).
+
+   Acceptance check for this step (before writing tests): `src/app/page.tsx` should no longer mention `sessions.list`, `chat.history`, or `cron.list` inside a latest-update refresh helper. Those gateway calls should only exist in `src/features/agents/operations/specialLatestUpdateOperation.ts` after extraction.
+
+3. Add unit tests for the extracted operation in `tests/unit/specialLatestUpdateOperation.test.ts`.
+
+   Follow the existing testing style (see `tests/unit/agentFleetHydration.test.ts` for stubbing `client.call` with `vi.fn`).
+
+   Write tests that validate behavior with plain stubs and no React rendering:
+
+   - `it("dispatches reset patch when intent resolves to reset")`:
+     - Construct the operation with a stubbed `dispatchUpdateAgent` and `callGateway` that would throw if invoked.
+     - Call `update(agent.agentId, agent, "plain user prompt")` with `agent.latestOverrideKind` pre-set to force `hasExistingOverride: true`.
+     - Assert `dispatchUpdateAgent` was called with `buildLatestUpdatePatch("")`.
+
+   - `it("selects heartbeat session, reads history, and stores last assistant response after a heartbeat prompt")`:
+     - Stub `callGateway` for `sessions.list` to return `sessions` entries where only one has `origin.label: "heartbeat"` and that one has the highest `updatedAt`.
+     - Stub `callGateway` for `chat.history` to return `messages` that include:
+       - a user message whose extracted text matches `isHeartbeatPrompt` (use the real regex behavior by providing a message whose `content` begins with `Read HEARTBEAT.md if it exists`), followed by multiple assistant messages; the last such assistant message is the expected result.
+     - Assert the dispatched patch equals `buildLatestUpdatePatch(expected, "heartbeat")`.
+
+   - `it("fetches cron jobs, selects latest cron for agentId, and stores formatted cron display")`:
+     - Provide `listCronJobs` returning multiple jobs, including at least two with matching `agentId` and different `updatedAtMs`.
+     - Use the real `resolveLatestCronJobForAgent`/`formatCronJobDisplay` behavior by passing the same resolver/formatter as production (or stub the formatter to return a unique string and assert it is used).
+     - Assert dispatch uses `buildLatestUpdatePatch(content, "cron")`.
+
+   - `it("dedupes concurrent updates for same agentId while first is in flight")`:
+     - Make `callGateway("sessions.list", ...)` return a promise that you control (create it with `new Promise` and hold its resolver).
+     - Invoke `update(...)` twice for the same agent id before resolving the first promise.
+     - Assert `callGateway` was called only once for `sessions.list`.
+     - Resolve the promise and complete the flow so the test does not leak.
+
+4. Validate the refactor with the repo’s standard commands (run from `/Users/georgepickett/.codex/worktrees/f6bd/openclaw-studio`):
+
+   - `npm run typecheck`
+     Expected result: success with no output (exit code 0).
+
+   - `npm test`
+     Expected result: all unit tests pass, including the new `specialLatestUpdateOperation` tests.
+
+## Validation and Acceptance
+
+Code-level acceptance (verifiable):
+
+1. `src/app/page.tsx` no longer defines `findLatestHeartbeatResponse`, `updateSpecialLatestUpdate`, or `refreshHeartbeatLatestUpdate`, and it no longer contains the gateway call chain (`sessions.list` + `chat.history` + `cron.list`) that used to live in `updateSpecialLatestUpdate`.
+
+2. The extracted implementation lives in `src/features/agents/operations/specialLatestUpdateOperation.ts` and is unit-testable with stubbed dependencies. It must not import React hooks or read browser globals (`window`, `document`) directly.
+
+3. Unit tests in `tests/unit/specialLatestUpdateOperation.test.ts` demonstrate:
+   - heartbeat-session selection + history parsing behavior
+   - cron selection + formatting behavior
+   - per-agent in-flight dedupe behavior
+   - reset/noop semantics derived from `resolveLatestUpdateIntent`
+
+Manual smoke acceptance (optional but recommended):
+
+1. `npm run dev`
+2. Connect Studio to a gateway.
+3. For an agent, send a message containing “heartbeat” and confirm the fleet row’s latest update resolves to a derived heartbeat response.
+4. For an agent with cron jobs, send a message containing “cron” and confirm the fleet row’s latest update resolves to the formatted latest cron job display.
+
+## Idempotence and Recovery
+
+This refactor is additive and reversible:
+
+- Add one new file and update imports/wiring in `src/app/page.tsx`.
+- If anything goes wrong, `git checkout -- src/app/page.tsx` and `git checkout -- src/features/agents/operations/specialLatestUpdateOperation.ts` reverts the entire change.
+
+## Artifacts and Notes
+
+Revision note (2026-02-15): Strengthened this ExecPlan by reading the actual call sites and adding the missing wiring constraint from `handleNewSession` (`src/app/page.tsx:1837`) that clears the special-update in-flight guard. Corrected the agent-scan call site reference to `src/app/page.tsx:1225` and grounded the runtime-handler dependency path (`src/features/agents/state/gatewayRuntimeEventHandler.ts:331`). Rewrote the extraction steps to specify an explicit operation interface (`update`, `refreshHeartbeat`, `clearInFlight`) and concrete dependency injection matching existing repo test patterns.

--- a/src/features/agents/operations/executionRoleUpdateOperation.ts
+++ b/src/features/agents/operations/executionRoleUpdateOperation.ts
@@ -1,0 +1,166 @@
+import type { GatewayClient } from "@/lib/gateway/GatewayClient";
+import { syncGatewaySessionSettings } from "@/lib/gateway/GatewayClient";
+import {
+  readGatewayAgentExecApprovals,
+  upsertGatewayAgentExecApprovals,
+} from "@/lib/gateway/execApprovals";
+import { readConfigAgentList, updateGatewayAgentOverrides } from "@/lib/gateway/agentConfig";
+
+export type ExecutionRoleId = "conservative" | "collaborative" | "autonomous";
+
+export function resolveExecApprovalsPolicyForRole(params: {
+  role: ExecutionRoleId;
+  allowlist: Array<{ pattern: string }>;
+}):
+  | {
+      security: "full" | "allowlist";
+      ask: "off" | "always";
+      allowlist: Array<{ pattern: string }>;
+    }
+  | null {
+  if (params.role === "conservative") return null;
+  if (params.role === "autonomous") {
+    return { security: "full", ask: "off", allowlist: params.allowlist };
+  }
+  return { security: "allowlist", ask: "always", allowlist: params.allowlist };
+}
+
+const coerceStringArray = (value: unknown): string[] | null => {
+  if (!Array.isArray(value)) return null;
+  return value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value && typeof value === "object" && !Array.isArray(value));
+
+export function resolveRuntimeToolOverridesForRole(params: {
+  role: ExecutionRoleId;
+  existingTools: unknown;
+}): { tools: { allow?: string[]; alsoAllow?: string[]; deny?: string[] } } {
+  const tools = isRecord(params.existingTools) ? params.existingTools : null;
+
+  const existingAllow = coerceStringArray(tools?.allow);
+  const existingAlsoAllow = coerceStringArray(tools?.alsoAllow);
+  const existingDeny = coerceStringArray(tools?.deny) ?? [];
+
+  const usesAllow = existingAllow !== null;
+  const baseAllowed = new Set(usesAllow ? existingAllow : existingAlsoAllow ?? []);
+  const deny = new Set(existingDeny);
+
+  if (params.role === "conservative") {
+    baseAllowed.delete("group:runtime");
+    deny.add("group:runtime");
+  } else {
+    baseAllowed.add("group:runtime");
+    deny.delete("group:runtime");
+  }
+
+  const allowedList = Array.from(baseAllowed);
+  const denyList = Array.from(deny).filter((entry) => !baseAllowed.has(entry));
+
+  return {
+    tools: usesAllow ? { allow: allowedList, deny: denyList } : { alsoAllow: allowedList, deny: denyList },
+  };
+}
+
+export function resolveSessionExecSettingsForRole(params: {
+  role: ExecutionRoleId;
+  sandboxMode: string;
+}): {
+  execHost: "sandbox" | "gateway" | null;
+  execSecurity: "deny" | "allowlist" | "full";
+  execAsk: "off" | "always";
+} {
+  if (params.role === "conservative") {
+    return { execHost: null, execSecurity: "deny", execAsk: "off" };
+  }
+
+  const normalizedMode = params.sandboxMode.trim().toLowerCase();
+  const execHost = normalizedMode === "all" ? "sandbox" : "gateway";
+  if (params.role === "autonomous") {
+    return { execHost, execSecurity: "full", execAsk: "off" };
+  }
+  return { execHost, execSecurity: "allowlist", execAsk: "always" };
+}
+
+export async function updateExecutionRoleViaStudio(params: {
+  client: GatewayClient;
+  agentId: string;
+  sessionKey: string;
+  role: ExecutionRoleId;
+  loadAgents: () => Promise<void>;
+}): Promise<void> {
+  const agentId = params.agentId.trim();
+  if (!agentId) {
+    throw new Error("Agent id is required.");
+  }
+
+  const existingPolicy = await readGatewayAgentExecApprovals({
+    client: params.client,
+    agentId,
+  });
+  const allowlist = existingPolicy?.allowlist ?? [];
+  const nextPolicy = resolveExecApprovalsPolicyForRole({ role: params.role, allowlist });
+
+  await upsertGatewayAgentExecApprovals({
+    client: params.client,
+    agentId,
+    policy: nextPolicy,
+  });
+
+  const snapshot = await params.client.call<{ config?: unknown }>("config.get", {});
+  const baseConfig =
+    snapshot.config && typeof snapshot.config === "object" && !Array.isArray(snapshot.config)
+      ? (snapshot.config as Record<string, unknown>)
+      : undefined;
+
+  const list = readConfigAgentList(baseConfig);
+  const configEntry = list.find((entry) => entry.id === agentId) ?? null;
+
+  const sandboxRaw =
+    configEntry && typeof (configEntry as Record<string, unknown>).sandbox === "object"
+      ? ((configEntry as Record<string, unknown>).sandbox as unknown)
+      : null;
+  const sandbox =
+    sandboxRaw && typeof sandboxRaw === "object" && !Array.isArray(sandboxRaw)
+      ? (sandboxRaw as Record<string, unknown>)
+      : null;
+  const sandboxMode = typeof sandbox?.mode === "string" ? sandbox.mode.trim().toLowerCase() : "";
+
+  const toolsRaw =
+    configEntry && typeof (configEntry as Record<string, unknown>).tools === "object"
+      ? ((configEntry as Record<string, unknown>).tools as unknown)
+      : null;
+  const tools =
+    toolsRaw && typeof toolsRaw === "object" && !Array.isArray(toolsRaw)
+      ? (toolsRaw as Record<string, unknown>)
+      : null;
+
+  const toolOverrides = resolveRuntimeToolOverridesForRole({
+    role: params.role,
+    existingTools: tools,
+  });
+  await updateGatewayAgentOverrides({
+    client: params.client,
+    agentId,
+    overrides: toolOverrides,
+  });
+
+  const execSettings = resolveSessionExecSettingsForRole({
+    role: params.role,
+    sandboxMode,
+  });
+  await syncGatewaySessionSettings({
+    client: params.client,
+    sessionKey: params.sessionKey,
+    execHost: execSettings.execHost,
+    execSecurity: execSettings.execSecurity,
+    execAsk: execSettings.execAsk,
+  });
+
+  await params.loadAgents();
+}
+

--- a/src/features/agents/operations/specialLatestUpdateOperation.ts
+++ b/src/features/agents/operations/specialLatestUpdateOperation.ts
@@ -1,0 +1,147 @@
+import type { CronJobSummary } from "@/lib/cron/types";
+import {
+  buildLatestUpdatePatch,
+  resolveLatestUpdateIntent,
+} from "@/features/agents/operations/latestUpdateWorkflow";
+import type { AgentState } from "@/features/agents/state/store";
+import { extractText, isHeartbeatPrompt, stripUiMetadata } from "@/lib/text/message-extract";
+
+type ChatHistoryMessage = Record<string, unknown>;
+
+type ChatHistoryResult = {
+  messages?: ChatHistoryMessage[];
+};
+
+type SessionsListEntry = {
+  key?: string;
+  updatedAt?: number | null;
+  origin?: { label?: string | null } | null;
+};
+
+type SessionsListResult = {
+  sessions?: SessionsListEntry[];
+};
+
+const findLatestHeartbeatResponse = (messages: ChatHistoryMessage[]) => {
+  let awaitingHeartbeatReply = false;
+  let latestResponse: string | null = null;
+  for (const message of messages) {
+    const role = typeof message.role === "string" ? message.role : "";
+    if (role === "user") {
+      const text = stripUiMetadata(extractText(message) ?? "").trim();
+      awaitingHeartbeatReply = isHeartbeatPrompt(text);
+      continue;
+    }
+    if (role === "assistant" && awaitingHeartbeatReply) {
+      const text = stripUiMetadata(extractText(message) ?? "").trim();
+      if (text) {
+        latestResponse = text;
+      }
+    }
+  }
+  return latestResponse;
+};
+
+export type SpecialLatestUpdateDeps = {
+  callGateway: (method: string, params: unknown) => Promise<unknown>;
+  listCronJobs: () => Promise<{ jobs: CronJobSummary[] }>;
+  resolveCronJobForAgent: (jobs: CronJobSummary[], agentId: string) => CronJobSummary | null;
+  formatCronJobDisplay: (job: CronJobSummary) => string;
+  dispatchUpdateAgent: (
+    agentId: string,
+    patch: { latestOverride: string | null; latestOverrideKind: "heartbeat" | "cron" | null }
+  ) => void;
+  isDisconnectLikeError: (err: unknown) => boolean;
+  logError: (message: string) => void;
+};
+
+export type SpecialLatestUpdateOperation = {
+  update: (agentId: string, agent: AgentState, message: string) => Promise<void>;
+  refreshHeartbeat: (agents: AgentState[]) => void;
+  clearInFlight: (agentId: string) => void;
+};
+
+export function createSpecialLatestUpdateOperation(
+  deps: SpecialLatestUpdateDeps
+): SpecialLatestUpdateOperation {
+  const inFlight = new Set<string>();
+
+  const update: SpecialLatestUpdateOperation["update"] = async (agentId, agent, message) => {
+    const intent = resolveLatestUpdateIntent({
+      message,
+      agentId: agent.agentId,
+      sessionKey: agent.sessionKey,
+      hasExistingOverride: Boolean(agent.latestOverride || agent.latestOverrideKind),
+    });
+    if (intent.kind === "noop") return;
+    if (intent.kind === "reset") {
+      deps.dispatchUpdateAgent(agent.agentId, buildLatestUpdatePatch(""));
+      return;
+    }
+
+    const key = agentId;
+    if (inFlight.has(key)) return;
+    inFlight.add(key);
+
+    try {
+      if (intent.kind === "fetch-heartbeat") {
+        const result = (await deps.callGateway("sessions.list", {
+          agentId: intent.agentId,
+          includeGlobal: false,
+          includeUnknown: false,
+          limit: intent.sessionLimit,
+        })) as SessionsListResult;
+
+        const entries = Array.isArray(result.sessions) ? result.sessions : [];
+        const heartbeatSessions = entries.filter((entry) => {
+          const label = entry.origin?.label;
+          return typeof label === "string" && label.toLowerCase() === "heartbeat";
+        });
+        const candidates = heartbeatSessions.length > 0 ? heartbeatSessions : entries;
+        const sorted = [...candidates].sort((a, b) => (b.updatedAt ?? 0) - (a.updatedAt ?? 0));
+        const sessionKey = sorted[0]?.key;
+        if (!sessionKey) {
+          deps.dispatchUpdateAgent(agent.agentId, buildLatestUpdatePatch(""));
+          return;
+        }
+
+        const history = (await deps.callGateway("chat.history", {
+          sessionKey,
+          limit: intent.historyLimit,
+        })) as ChatHistoryResult;
+        const messages = Array.isArray(history.messages) ? history.messages : [];
+        const content = findLatestHeartbeatResponse(messages) ?? "";
+        deps.dispatchUpdateAgent(agent.agentId, buildLatestUpdatePatch(content, "heartbeat"));
+        return;
+      }
+
+      if (intent.kind === "fetch-cron") {
+        const cronResult = await deps.listCronJobs();
+        const job = deps.resolveCronJobForAgent(cronResult.jobs, intent.agentId);
+        const content = job ? deps.formatCronJobDisplay(job) : "";
+        deps.dispatchUpdateAgent(agent.agentId, buildLatestUpdatePatch(content, "cron"));
+      }
+    } catch (err) {
+      if (!deps.isDisconnectLikeError(err)) {
+        const message =
+          err instanceof Error ? err.message : "Failed to load latest cron/heartbeat update.";
+        deps.logError(message);
+      }
+    } finally {
+      inFlight.delete(key);
+    }
+  };
+
+  const refreshHeartbeat: SpecialLatestUpdateOperation["refreshHeartbeat"] = (agents) => {
+    for (const agent of agents) {
+      void update(agent.agentId, agent, "heartbeat");
+    }
+  };
+
+  const clearInFlight: SpecialLatestUpdateOperation["clearInFlight"] = (agentId) => {
+    inFlight.delete(agentId);
+  };
+
+  return { update, refreshHeartbeat, clearInFlight };
+}
+

--- a/tests/unit/executionRoleUpdateOperation.test.ts
+++ b/tests/unit/executionRoleUpdateOperation.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveExecApprovalsPolicyForRole,
+  resolveRuntimeToolOverridesForRole,
+  resolveSessionExecSettingsForRole,
+} from "@/features/agents/operations/executionRoleUpdateOperation";
+
+describe("executionRoleUpdateOperation", () => {
+  it("maps roles to exec approvals policy while preserving allowlist", () => {
+    const allowlist = [{ pattern: "a" }, { pattern: "b" }];
+
+    expect(resolveExecApprovalsPolicyForRole({ role: "conservative", allowlist })).toBeNull();
+
+    const collaborative = resolveExecApprovalsPolicyForRole({
+      role: "collaborative",
+      allowlist,
+    });
+    expect(collaborative).toEqual({
+      security: "allowlist",
+      ask: "always",
+      allowlist,
+    });
+    expect(collaborative?.allowlist).toBe(allowlist);
+
+    const autonomous = resolveExecApprovalsPolicyForRole({
+      role: "autonomous",
+      allowlist,
+    });
+    expect(autonomous).toEqual({
+      security: "full",
+      ask: "off",
+      allowlist,
+    });
+    expect(autonomous?.allowlist).toBe(allowlist);
+  });
+
+  it("updates tool overrides using allow when existing tools.allow is present", () => {
+    const existingTools = { allow: ["group:web"], deny: ["group:runtime"] };
+
+    const collaborative = resolveRuntimeToolOverridesForRole({
+      role: "collaborative",
+      existingTools,
+    });
+    expect(collaborative.tools.allow).toEqual(expect.arrayContaining(["group:web", "group:runtime"]));
+    expect(collaborative.tools).not.toHaveProperty("alsoAllow");
+    expect(collaborative.tools.deny).not.toEqual(expect.arrayContaining(["group:runtime"]));
+
+    const autonomous = resolveRuntimeToolOverridesForRole({
+      role: "autonomous",
+      existingTools,
+    });
+    expect(autonomous.tools.allow).toEqual(expect.arrayContaining(["group:web", "group:runtime"]));
+    expect(autonomous.tools).not.toHaveProperty("alsoAllow");
+    expect(autonomous.tools.deny).not.toEqual(expect.arrayContaining(["group:runtime"]));
+
+    const conservative = resolveRuntimeToolOverridesForRole({
+      role: "conservative",
+      existingTools,
+    });
+    expect(conservative.tools.allow).toEqual(expect.arrayContaining(["group:web"]));
+    expect(conservative.tools.allow).not.toEqual(expect.arrayContaining(["group:runtime"]));
+    expect(conservative.tools.deny).toEqual(expect.arrayContaining(["group:runtime"]));
+  });
+
+  it("updates tool overrides using alsoAllow when tools.allow is absent", () => {
+    const existingTools = { alsoAllow: ["group:web"], deny: [] as string[] };
+
+    const collaborative = resolveRuntimeToolOverridesForRole({
+      role: "collaborative",
+      existingTools,
+    });
+    expect(collaborative.tools.alsoAllow).toEqual(expect.arrayContaining(["group:web", "group:runtime"]));
+    expect(collaborative.tools).not.toHaveProperty("allow");
+
+    const conservative = resolveRuntimeToolOverridesForRole({
+      role: "conservative",
+      existingTools,
+    });
+    expect(conservative.tools.alsoAllow).toEqual(expect.arrayContaining(["group:web"]));
+    expect(conservative.tools.alsoAllow).not.toEqual(expect.arrayContaining(["group:runtime"]));
+    expect(conservative.tools.deny).toEqual(expect.arrayContaining(["group:runtime"]));
+  });
+
+  it("resolves session exec settings from role and sandbox mode", () => {
+    expect(resolveSessionExecSettingsForRole({ role: "conservative", sandboxMode: "all" })).toEqual({
+      execHost: null,
+      execSecurity: "deny",
+      execAsk: "off",
+    });
+
+    expect(resolveSessionExecSettingsForRole({ role: "collaborative", sandboxMode: "all" }).execHost).toBe(
+      "sandbox"
+    );
+    expect(resolveSessionExecSettingsForRole({ role: "autonomous", sandboxMode: "all" }).execHost).toBe(
+      "sandbox"
+    );
+
+    expect(resolveSessionExecSettingsForRole({ role: "collaborative", sandboxMode: "none" }).execHost).toBe(
+      "gateway"
+    );
+    expect(resolveSessionExecSettingsForRole({ role: "autonomous", sandboxMode: "none" }).execHost).toBe(
+      "gateway"
+    );
+  });
+
+  it("treats missing tools config as empty lists and still enforces group:runtime semantics", () => {
+    const collaborative = resolveRuntimeToolOverridesForRole({
+      role: "collaborative",
+      existingTools: null,
+    });
+    expect(collaborative.tools.alsoAllow).toEqual(expect.arrayContaining(["group:runtime"]));
+    expect(collaborative.tools).not.toHaveProperty("allow");
+  });
+});
+

--- a/tests/unit/specialLatestUpdateOperation.test.ts
+++ b/tests/unit/specialLatestUpdateOperation.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { buildLatestUpdatePatch } from "@/features/agents/operations/latestUpdateWorkflow";
+import { createSpecialLatestUpdateOperation } from "@/features/agents/operations/specialLatestUpdateOperation";
+import { resolveLatestCronJobForAgent, type CronJobSummary } from "@/lib/cron/types";
+import type { AgentState } from "@/features/agents/state/store";
+
+const makeAgent = (overrides?: Partial<Pick<AgentState, "agentId" | "sessionKey" | "latestOverride" | "latestOverrideKind">>) => {
+  return {
+    agentId: "agent-1",
+    sessionKey: "agent:agent-1:main",
+    latestOverride: null,
+    latestOverrideKind: null,
+    ...overrides,
+  } as unknown as AgentState;
+};
+
+describe("specialLatestUpdateOperation", () => {
+  it("dispatches reset patch when intent resolves to reset", async () => {
+    const agent = makeAgent({ latestOverrideKind: "cron" });
+
+    const dispatchUpdateAgent = vi.fn();
+    const operation = createSpecialLatestUpdateOperation({
+      callGateway: async () => {
+        throw new Error("callGateway should not be invoked for reset intent");
+      },
+      listCronJobs: async () => ({ jobs: [] }),
+      resolveCronJobForAgent: () => null,
+      formatCronJobDisplay: () => "",
+      dispatchUpdateAgent,
+      isDisconnectLikeError: () => false,
+      logError: () => {},
+    });
+
+    await operation.update(agent.agentId, agent, "plain user prompt");
+
+    expect(dispatchUpdateAgent).toHaveBeenCalledTimes(1);
+    expect(dispatchUpdateAgent).toHaveBeenCalledWith(agent.agentId, buildLatestUpdatePatch(""));
+  });
+
+  it("selects heartbeat session, reads history, and stores last assistant response after a heartbeat prompt", async () => {
+    const agent = makeAgent();
+
+    const callGateway = vi.fn(async (method: string) => {
+      if (method === "sessions.list") {
+        return {
+          sessions: [
+            { key: "agent:agent-1:main", updatedAt: 200, origin: { label: "main" } },
+            { key: "agent:agent-1:hb", updatedAt: 100, origin: { label: "Heartbeat" } },
+          ],
+        };
+      }
+      if (method === "chat.history") {
+        return {
+          messages: [
+            { role: "user", content: "Read HEARTBEAT.md if it exists" },
+            { role: "assistant", content: "First response" },
+            { role: "assistant", content: "Second response" },
+          ],
+        };
+      }
+      throw new Error(`Unhandled gateway method: ${method}`);
+    });
+
+    const dispatchUpdateAgent = vi.fn();
+    const operation = createSpecialLatestUpdateOperation({
+      callGateway,
+      listCronJobs: async () => ({ jobs: [] }),
+      resolveCronJobForAgent: () => null,
+      formatCronJobDisplay: () => "",
+      dispatchUpdateAgent,
+      isDisconnectLikeError: () => false,
+      logError: () => {},
+    });
+
+    await operation.update(agent.agentId, agent, "heartbeat please");
+
+    expect(callGateway).toHaveBeenCalledWith("sessions.list", expect.anything());
+    expect(callGateway).toHaveBeenCalledWith("chat.history", expect.anything());
+    expect(dispatchUpdateAgent).toHaveBeenCalledWith(
+      agent.agentId,
+      buildLatestUpdatePatch("Second response", "heartbeat")
+    );
+  });
+
+  it("fetches cron jobs, selects latest cron for agentId, and stores formatted cron display", async () => {
+    const agent = makeAgent();
+
+    const jobs: CronJobSummary[] = [
+      {
+        id: "job-1",
+        name: "Older",
+        agentId: "agent-1",
+        enabled: true,
+        updatedAtMs: 1,
+        schedule: { kind: "every", everyMs: 60000 },
+        sessionTarget: "main",
+        wakeMode: "now",
+        payload: { kind: "systemEvent", text: "one" },
+        state: {},
+      },
+      {
+        id: "job-2",
+        name: "Newer",
+        agentId: "agent-1",
+        enabled: true,
+        updatedAtMs: 2,
+        schedule: { kind: "every", everyMs: 60000 },
+        sessionTarget: "main",
+        wakeMode: "now",
+        payload: { kind: "systemEvent", text: "two" },
+        state: {},
+      },
+    ];
+
+    const dispatchUpdateAgent = vi.fn();
+    const operation = createSpecialLatestUpdateOperation({
+      callGateway: async () => {
+        throw new Error("callGateway should not be invoked for cron intent");
+      },
+      listCronJobs: async () => ({ jobs }),
+      resolveCronJobForAgent: resolveLatestCronJobForAgent,
+      formatCronJobDisplay: (job) => `formatted:${job.id}`,
+      dispatchUpdateAgent,
+      isDisconnectLikeError: () => false,
+      logError: () => {},
+    });
+
+    await operation.update(agent.agentId, agent, "cron report pending");
+
+    expect(dispatchUpdateAgent).toHaveBeenCalledWith(
+      agent.agentId,
+      buildLatestUpdatePatch("formatted:job-2", "cron")
+    );
+  });
+
+  it("dedupes concurrent updates for same agentId while first is in flight", async () => {
+    const agent = makeAgent();
+
+    let resolveSessions!: (value: unknown) => void;
+    const sessionsPromise = new Promise<unknown>((resolve) => {
+      resolveSessions = resolve;
+    });
+
+    const callGateway = vi.fn((method: string) => {
+      if (method === "sessions.list") {
+        return sessionsPromise;
+      }
+      if (method === "chat.history") {
+        return Promise.resolve({
+          messages: [
+            { role: "user", content: "Read HEARTBEAT.md if it exists" },
+            { role: "assistant", content: "ok" },
+          ],
+        });
+      }
+      return Promise.reject(new Error(`Unhandled gateway method: ${method}`));
+    });
+
+    const dispatchUpdateAgent = vi.fn();
+    const operation = createSpecialLatestUpdateOperation({
+      callGateway,
+      listCronJobs: async () => ({ jobs: [] }),
+      resolveCronJobForAgent: () => null,
+      formatCronJobDisplay: () => "",
+      dispatchUpdateAgent,
+      isDisconnectLikeError: () => false,
+      logError: () => {},
+    });
+
+    const first = operation.update(agent.agentId, agent, "heartbeat please");
+    const second = operation.update(agent.agentId, agent, "heartbeat please");
+    await second;
+
+    expect(callGateway).toHaveBeenCalledTimes(1);
+    expect(callGateway).toHaveBeenCalledWith("sessions.list", expect.anything());
+
+    resolveSessions({
+      sessions: [{ key: "agent:agent-1:hb", updatedAt: 1, origin: { label: "heartbeat" } }],
+    });
+    await first;
+
+    expect(callGateway).toHaveBeenCalledTimes(2);
+    expect(callGateway).toHaveBeenCalledWith("chat.history", expect.anything());
+    expect(dispatchUpdateAgent).toHaveBeenCalledWith(
+      agent.agentId,
+      buildLatestUpdatePatch("ok", "heartbeat")
+    );
+  });
+});


### PR DESCRIPTION
Summary:
- Extract latest-update handling into `specialLatestUpdateOperation` and wire it through `AgentStudioPage` to keep the UI focused on view/state management
- Move execution-role mutation logic into `executionRoleUpdateOperation`, covering approvals policy, tool overrides, and session settings so the page just delegates to the reusable helper
- Add unit tests that lock down the new execution-role helper exports and their semantics

Testing:
- Not run (not requested)