### PR TITLE
Strip timestamp envelopes to collapse duplicate user messages

### DIFF
--- a/src/lib/text/message-extract.ts
+++ b/src/lib/text/message-extract.ts
@@ -539,7 +539,7 @@ export const stripUiMetadata = (text: string) => {
     cleaned = cleaned.replace(PROJECT_PROMPT_BLOCK_RE, "");
   }
   cleaned = cleaned.replace(MESSAGE_ID_RE, "").trim();
-  return cleaned;
+  return stripEnvelope(cleaned);
 };
 
 export const isHeartbeatPrompt = (text: string) => {

--- a/tests/unit/messageExtract.test.ts
+++ b/tests/unit/messageExtract.test.ts
@@ -104,7 +104,7 @@ describe("message-extract", () => {
 [Thu 2026-02-12 01:14 UTC] nope none of those are it. keep looking
 [message_id: e050a641-aa32-4950-8083-c3bb7efdfc6d]`;
 
-    expect(stripUiMetadata(raw)).toBe("[Thu 2026-02-12 01:14 UTC] nope none of those are it. keep looking");
+    expect(stripUiMetadata(raw)).toBe("nope none of those are it. keep looking");
   });
 
   it("hides internal exec approval auto-resume messages from transcript text", () => {

--- a/tests/unit/runtimeEventBridge.test.ts
+++ b/tests/unit/runtimeEventBridge.test.ts
@@ -511,4 +511,28 @@ Continue where you left off and finish the task.`,
       historyLoadedAt: 400,
     });
   });
+
+  it("collapses optimistic user lines when history carries a post-system timestamp envelope", () => {
+    const patch = buildHistorySyncPatch({
+      messages: [
+        {
+          role: "user",
+          timestamp: "2026-02-17T23:39:00.000Z",
+          content:
+            "System: [2026-02-17 23:38 UTC] queued\n\n[Tue 2026-02-17 23:39 UTC] Ask me some questions",
+        },
+      ],
+      currentLines: ["> Ask me some questions"],
+      loadedAt: 500,
+      status: "idle",
+      runId: null,
+    });
+
+    expect(patch).toEqual({
+      outputLines: ['[[meta]]{"role":"user","timestamp":1771371540000}', "> Ask me some questions"],
+      lastResult: null,
+      lastUserMessage: "Ask me some questions",
+      historyLoadedAt: 500,
+    });
+  });
 });


### PR DESCRIPTION
Summary
- ensure `stripUiMetadata` removes timestamp envelopes so matching statements aren’t treated as different messages
- add regression coverage for history sync collapsing optimistic lines when the server provides a post-system timestamp envelope

Testing
- Not run (not requested)