### PR TITLE
Fix plug icon popover background

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -694,6 +694,10 @@ textarea:focus::-webkit-scrollbar {
     0 1px 2px color-mix(in oklch, var(--foreground) 10%, transparent);
 }
 
+.ui-menu-popover {
+  background: var(--popover);
+}
+
 .ui-card-selected {
   border-color: var(--surface-selected-border);
   background: var(--surface-selected);

--- a/src/features/agents/components/HeaderBar.tsx
+++ b/src/features/agents/components/HeaderBar.tsx
@@ -70,7 +70,7 @@ export const HeaderBar = ({
                 <span className="sr-only">Open studio menu</span>
               </button>
               {menuOpen ? (
-                <div className="ui-card absolute right-0 top-11 z-[260] min-w-44 p-1">
+                <div className="ui-card ui-menu-popover absolute right-0 top-11 z-[260] min-w-44 p-1">
                   <button
                     className="ui-btn-ghost w-full justify-start border-transparent px-3 py-2 text-left text-xs font-medium tracking-normal text-foreground"
                     type="button"


### PR DESCRIPTION
Summary
- ensure popover menus share the same popover background color
- apply the new class to the plug icon dropdown so its background is opaque

Testing
- Not run (not requested)