### PR TITLE
Move agent rename control to chat header

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2359,6 +2359,7 @@ const AgentStudioPage = () => {
                     stopDisabledReason={focusedAgentStopDisabledReason}
                     onLoadMoreHistory={() => loadMoreAgentHistory(focusedAgent.agentId)}
                     onOpenSettings={() => handleOpenAgentPersonality(focusedAgent.agentId)}
+                    onRename={(name) => handleRenameAgent(focusedAgent.agentId, name)}
                     onNewSession={() => handleNewSession(focusedAgent.agentId)}
                     onModelChange={(value) =>
                       handleModelChange(focusedAgent.agentId, focusedAgent.sessionKey, value)
@@ -2437,7 +2438,6 @@ const AgentStudioPage = () => {
                     client={client}
                     agents={agents}
                     selectedAgentId={inspectSidebarAgent.agentId}
-                    onRename={(name) => handleRenameAgent(inspectSidebarAgent.agentId, name)}
                     onClose={() => {
                       setInspectSidebar(null);
                       setMobilePane("chat");

--- a/src/features/agents/components/AgentCreateModal.tsx
+++ b/src/features/agents/components/AgentCreateModal.tsx
@@ -92,7 +92,7 @@ const AgentCreateModalContent = ({
             />
           </label>
           <div className="-mt-2 text-[11px] text-muted-foreground">
-            You can rename this agent later in settings.
+            You can rename this agent from the main chat header.
           </div>
           <div className="grid justify-items-center gap-2 border-t border-border/40 pt-3">
             <div className={labelClassName}>Choose avatar</div>

--- a/tests/unit/agentBrainPanel.test.ts
+++ b/tests/unit/agentBrainPanel.test.ts
@@ -107,7 +107,6 @@ describe("AgentBrainPanel", () => {
         client,
         agents,
         selectedAgentId: "agent-1",
-        onRename: vi.fn(async () => true),
         onClose: vi.fn(),
       })
     );
@@ -139,7 +138,6 @@ describe("AgentBrainPanel", () => {
         client,
         agents,
         selectedAgentId: "",
-        onRename: vi.fn(async () => true),
         onClose: vi.fn(),
       })
     );
@@ -159,7 +157,6 @@ describe("AgentBrainPanel", () => {
         client,
         agents,
         selectedAgentId: "agent-1",
-        onRename: vi.fn(async () => true),
         onClose,
       })
     );
@@ -205,28 +202,23 @@ describe("AgentBrainPanel", () => {
     ).toContain("- Name: Alpha Prime");
   });
 
-  it("renames_agent_from_personality_panel", async () => {
+  it("does_not_render_name_editor_in_personality_panel", async () => {
     const { client } = createMockClient();
     const agents = [createAgent("agent-1", "Alpha", "session-1")];
-    const onRename = vi.fn(async () => true);
 
     render(
       createElement(AgentBrainPanel, {
         client,
         agents,
         selectedAgentId: "agent-1",
-        onRename,
         onClose: vi.fn(),
       })
     );
 
-    fireEvent.change(screen.getByLabelText("Agent name"), {
-      target: { value: "  Alpha Prime  " },
-    });
-    fireEvent.click(screen.getByRole("button", { name: "Update Name" }));
-
     await waitFor(() => {
-      expect(onRename).toHaveBeenCalledWith("Alpha Prime");
+      expect(screen.getByRole("button", { name: "Personality" })).toBeInTheDocument();
     });
+    expect(screen.queryByLabelText("Agent name")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Update Name" })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Summary
- add inline agent rename flow to the chat header with pencil button, edit input, save/cancel buttons, and client-side validation
- remove personality panel name edit UI and related rename hooks
- retain rename capability via chat context and update tests to cover new flow

Testing
- Not run (not requested)