### PR TITLE
feat: add cron jobs, sessions, and captures/TODOs pages

### DIFF
--- a/src/app/api/cron/reports/route.ts
+++ b/src/app/api/cron/reports/route.ts
@@ -1,0 +1,82 @@
+import { readFileSync, readdirSync, existsSync, statSync } from 'fs';
+import path from 'path';
+
+// Security: only allow reading from known safe base paths
+const ALLOWED_BASES = [
+  path.join(process.env.HOME || process.env.USERPROFILE || '', '.openclaw', 'workspace'),
+];
+
+function isSafePath(filePath: string): boolean {
+  const resolved = path.resolve(filePath);
+  return ALLOWED_BASES.some(base => resolved.startsWith(path.resolve(base)));
+}
+
+// GET /api/cron/reports?dir=<path>&file=<filename>
+// Without file: list files in directory
+// With file: return file content
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const dir = searchParams.get('dir');
+  const file = searchParams.get('file');
+
+  if (!dir) {
+    return Response.json({ error: 'dir parameter is required' }, { status: 400 });
+  }
+
+  if (!isSafePath(dir)) {
+    return Response.json({ error: 'Access denied' }, { status: 403 });
+  }
+
+  if (!existsSync(dir)) {
+    return Response.json({ files: [], error: null }, { headers: { 'Cache-Control': 'no-store' } });
+  }
+
+  // Return file content
+  if (file) {
+    const filePath = path.join(dir, path.basename(file)); // basename prevents traversal
+    if (!isSafePath(filePath) || !existsSync(filePath)) {
+      return Response.json({ error: 'File not found' }, { status: 404 });
+    }
+
+    try {
+      const content = readFileSync(filePath, 'utf-8');
+      const stat = statSync(filePath);
+      return Response.json({
+        name: path.basename(filePath),
+        content,
+        size: stat.size,
+        modified: stat.mtime.toISOString(),
+      }, { headers: { 'Cache-Control': 'no-store' } });
+    } catch (error) {
+      console.error('Error reading file:', error);
+      return Response.json({ error: 'Failed to read file' }, { status: 500 });
+    }
+  }
+
+  // List files in directory
+  try {
+    const entries = readdirSync(dir)
+      .filter(f => !f.startsWith('.'))
+      .map(f => {
+        const fp = path.join(dir, f);
+        try {
+          const stat = statSync(fp);
+          return {
+            name: f,
+            size: stat.size,
+            modified: stat.mtime.toISOString(),
+            isFile: stat.isFile(),
+          };
+        } catch {
+          return null;
+        }
+      })
+      .filter((f): f is NonNullable<typeof f> => f !== null && f.isFile)
+      .sort((a, b) => new Date(b.modified).getTime() - new Date(a.modified).getTime());
+
+    return Response.json({ files: entries }, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (error) {
+    console.error('Error listing directory:', error);
+    return Response.json({ error: 'Failed to list files' }, { status: 500 });
+  }
+}

--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -1,0 +1,167 @@
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+const CRON_JOBS_PATH = path.join(
+  process.env.HOME || process.env.USERPROFILE || '',
+  '.openclaw',
+  'cron',
+  'jobs.json'
+);
+
+type CronSchedule =
+  | { kind: 'at'; at: string }
+  | { kind: 'every'; everyMs: number; anchorMs?: number }
+  | { kind: 'cron'; expr: string; tz?: string };
+
+type CronPayload =
+  | { kind: 'systemEvent'; text: string }
+  | { kind: 'agentTurn'; message: string; [key: string]: unknown };
+
+type CronJobState = {
+  nextRunAtMs?: number;
+  runningAtMs?: number;
+  lastRunAtMs?: number;
+  lastStatus?: 'ok' | 'error' | 'skipped';
+  lastError?: string;
+  lastDurationMs?: number;
+};
+
+type CronDelivery = {
+  mode: 'none' | 'announce';
+  channel?: string;
+  to?: string;
+};
+
+type CronJob = {
+  id: string;
+  name: string;
+  agentId?: string;
+  enabled: boolean;
+  updatedAtMs: number;
+  schedule: CronSchedule;
+  sessionTarget: 'main' | 'isolated';
+  wakeMode: 'next-heartbeat' | 'now';
+  payload: CronPayload;
+  state: CronJobState;
+  delivery?: CronDelivery;
+};
+
+type CronJobsFile = {
+  version: number;
+  jobs: CronJob[];
+};
+
+function readJobs(): CronJobsFile {
+  if (!existsSync(CRON_JOBS_PATH)) {
+    return { version: 1, jobs: [] };
+  }
+  try {
+    return JSON.parse(readFileSync(CRON_JOBS_PATH, 'utf-8'));
+  } catch {
+    return { version: 1, jobs: [] };
+  }
+}
+
+function writeJobs(data: CronJobsFile) {
+  writeFileSync(CRON_JOBS_PATH, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+}
+
+// GET: List all cron jobs
+export async function GET() {
+  try {
+    const data = readJobs();
+    return Response.json(
+      { jobs: data.jobs, lastUpdated: new Date().toISOString() },
+      { headers: { 'Cache-Control': 'no-store' } }
+    );
+  } catch (error) {
+    console.error('Error reading cron jobs:', error);
+    return Response.json({ error: 'Failed to read cron jobs' }, { status: 500 });
+  }
+}
+
+// POST: Mutate cron jobs (add, remove, toggle, update)
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { action } = body as { action: string };
+
+    const data = readJobs();
+
+    switch (action) {
+      case 'add': {
+        const { name, schedule, payload, sessionTarget, wakeMode, agentId, delivery } = body;
+        if (!name || !schedule || !payload) {
+          return Response.json({ error: 'name, schedule, and payload are required' }, { status: 400 });
+        }
+
+        const newJob: CronJob = {
+          id: crypto.randomUUID(),
+          name,
+          agentId: agentId || undefined,
+          enabled: true,
+          updatedAtMs: Date.now(),
+          schedule,
+          sessionTarget: sessionTarget || 'isolated',
+          wakeMode: wakeMode || 'now',
+          payload,
+          state: {},
+          delivery: delivery || undefined,
+        };
+
+        data.jobs.push(newJob);
+        writeJobs(data);
+        return Response.json({ ok: true, job: newJob, jobs: data.jobs });
+      }
+
+      case 'remove': {
+        const { id } = body;
+        if (!id) return Response.json({ error: 'id is required' }, { status: 400 });
+
+        const idx = data.jobs.findIndex(j => j.id === id);
+        if (idx === -1) return Response.json({ error: 'Job not found' }, { status: 404 });
+
+        data.jobs.splice(idx, 1);
+        writeJobs(data);
+        return Response.json({ ok: true, jobs: data.jobs });
+      }
+
+      case 'toggle': {
+        const { id } = body;
+        if (!id) return Response.json({ error: 'id is required' }, { status: 400 });
+
+        const job = data.jobs.find(j => j.id === id);
+        if (!job) return Response.json({ error: 'Job not found' }, { status: 404 });
+
+        job.enabled = !job.enabled;
+        job.updatedAtMs = Date.now();
+        writeJobs(data);
+        return Response.json({ ok: true, job, jobs: data.jobs });
+      }
+
+      case 'update': {
+        const { id, name, schedule, payload, enabled, delivery } = body;
+        if (!id) return Response.json({ error: 'id is required' }, { status: 400 });
+
+        const job = data.jobs.find(j => j.id === id);
+        if (!job) return Response.json({ error: 'Job not found' }, { status: 404 });
+
+        if (name !== undefined) job.name = name;
+        if (schedule !== undefined) job.schedule = schedule;
+        if (payload !== undefined) job.payload = payload;
+        if (typeof enabled === 'boolean') job.enabled = enabled;
+        if (delivery !== undefined) job.delivery = delivery;
+        job.updatedAtMs = Date.now();
+        writeJobs(data);
+        return Response.json({ ok: true, job, jobs: data.jobs });
+      }
+
+      default:
+        return Response.json({ error: `Unknown action: ${action}` }, { status: 400 });
+    }
+  } catch (error) {
+    console.error('Error mutating cron jobs:', error);
+    return Response.json({ error: 'Failed to process request' }, { status: 500 });
+  }
+}

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -1,0 +1,113 @@
+import { readFileSync } from 'fs';
+import { existsSync } from 'fs';
+import path from 'path';
+import type { Session, SessionsData } from '@/types/sessions';
+
+export async function GET() {
+  try {
+    const logPath = path.join(
+      process.env.HOME || process.env.USERPROFILE || '',
+      '.openclaw',
+      'workspace',
+      'sessions.log'
+    );
+
+    // Return empty if log doesn't exist
+    if (!existsSync(logPath)) {
+      return Response.json(
+        {
+          active: [],
+          paused: [],
+          completed: [],
+          exited: [],
+          lastUpdated: new Date().toISOString(),
+        } as SessionsData,
+        { headers: { 'Cache-Control': 'no-store' } }
+      );
+    }
+
+    const logContent = readFileSync(logPath, 'utf-8').replace(/\r\n/g, '\n');
+    const lines = logContent.trim().split('\n').filter((l) => l);
+
+    // Track sessions
+    const sessions: Record<string, Session> = {};
+
+    for (const line of lines) {
+      // Parse format: [TIMESTAMP] ACTION project_name [details]
+      const match = line.match(/\[([^\]]+)\]\s+(START|PAUSED|RESUMED|DONE|EXIT)\s+(\S+)\s*(.*)/);
+      if (!match) continue;
+
+      const [, timestamp, action, projectName, details] = match;
+
+      if (!sessions[projectName]) {
+        sessions[projectName] = {
+          project: projectName,
+          status: 'active',
+          startTime: timestamp,
+          details: '',
+        };
+      }
+
+      switch (action) {
+        case 'START':
+          sessions[projectName].status = 'active';
+          sessions[projectName].startTime = timestamp;
+          sessions[projectName].details = details || '';
+          break;
+        case 'PAUSED':
+          sessions[projectName].status = 'paused';
+          sessions[projectName].details = details || 'waiting for input';
+          break;
+        case 'RESUMED':
+          sessions[projectName].status = 'active';
+          sessions[projectName].details = details || '';
+          break;
+        case 'EXIT':
+          sessions[projectName].status = 'exited';
+          sessions[projectName].endTime = timestamp;
+          sessions[projectName].details = details || 'interrupted';
+          break;
+        case 'DONE':
+          sessions[projectName].status = 'completed';
+          sessions[projectName].endTime = timestamp;
+          sessions[projectName].details = details || '';
+          break;
+      }
+    }
+
+    // Separate by status
+    const active = Object.values(sessions).filter((s) => s.status === 'active');
+    const paused = Object.values(sessions).filter((s) => s.status === 'paused');
+    const completed = Object.values(sessions).filter(
+      (s) => s.status === 'completed'
+    );
+    const exited = Object.values(sessions).filter((s) => s.status === 'exited');
+
+    // Sort by timestamp (newest first)
+    const sortByTime = (a: Session, b: Session) => {
+      const timeA = new Date(a.endTime || a.startTime).getTime();
+      const timeB = new Date(b.endTime || b.startTime).getTime();
+      return timeB - timeA;
+    };
+
+    active.sort(sortByTime);
+    completed.sort(sortByTime);
+
+    return Response.json(
+      {
+        active,
+        paused,
+        completed,
+        exited,
+        lastUpdated: new Date().toISOString(),
+      } as SessionsData,
+      { headers: { 'Cache-Control': 'no-store' } }
+    );
+  } catch (error) {
+    console.error('Error reading sessions:', error);
+    return Response.json(
+      { error: 'Failed to read sessions' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/todos/route.ts
+++ b/src/app/api/todos/route.ts
@@ -1,0 +1,175 @@
+import { readFileSync, writeFileSync, existsSync, statSync } from 'fs';
+import path from 'path';
+import type { TodoItem, TodosData } from '@/types/todos';
+
+const CAPTURES_PATH = path.join(
+  process.env.HOME || process.env.USERPROFILE || '',
+  'CAPTURES.md'
+);
+
+const HEADER = `# Captures — Quick Ideas from Telegram
+
+Quick captures via OpenClaw from Telegram. Review regularly and promote promising items elsewhere when ready.
+
+## Ideas\n`;
+
+function formatItem(item: { text: string; project?: string; completed: boolean }): string {
+  const check = item.completed ? 'x' : ' ';
+  const projectTag = item.project ? ` _(from ${item.project})_` : '';
+  return `- [${check}] ${item.text}${projectTag}`;
+}
+
+function readCaptures(): { items: TodoItem[]; rawLines: string[]; headerLines: string[] } {
+  if (!existsSync(CAPTURES_PATH)) {
+    return { items: [], rawLines: [], headerLines: HEADER.split('\n') };
+  }
+
+  const content = readFileSync(CAPTURES_PATH, 'utf-8').replace(/\r\n/g, '\n');
+  const allLines = content.split('\n');
+
+  const headerLines: string[] = [];
+  const itemLines: string[] = [];
+  let inItems = false;
+
+  for (const line of allLines) {
+    if (!inItems) {
+      headerLines.push(line);
+      // Start collecting items after "## Ideas" or similar heading
+      if (line.match(/^##\s/)) {
+        inItems = true;
+      }
+    } else {
+      itemLines.push(line);
+    }
+  }
+
+  const items: TodoItem[] = [];
+
+  for (const line of itemLines) {
+    const match = line.match(/^-\s+\[([ x])\]\s+(.+)$/);
+    if (!match) continue;
+
+    const completed = match[1] === 'x';
+    let text = match[2].trim();
+    let project: string | undefined;
+
+    const projectMatch = text.match(/\s*_\(from\s+(.+?)\)_\s*$/);
+    if (projectMatch) {
+      project = projectMatch[1];
+      text = text.replace(projectMatch[0], '').trim();
+    }
+
+    items.push({ text, project, completed, source: 'captures' });
+  }
+
+  return { items, rawLines: allLines, headerLines };
+}
+
+function writeCaptures(items: TodoItem[], headerLines: string[]) {
+  const itemLines = items.map(formatItem);
+  const content = headerLines.join('\n') + '\n' + itemLines.join('\n') + '\n';
+  writeFileSync(CAPTURES_PATH, content, 'utf-8');
+}
+
+export async function GET() {
+  try {
+    const { items } = readCaptures();
+
+    const lastUpdated = existsSync(CAPTURES_PATH)
+      ? statSync(CAPTURES_PATH).mtime.toISOString()
+      : new Date().toISOString();
+
+    return Response.json(
+      { items, lastUpdated } as TodosData,
+      { headers: { 'Cache-Control': 'no-store' } }
+    );
+  } catch (error) {
+    console.error('Error reading captures:', error);
+    return Response.json(
+      { error: 'Failed to read captures' },
+      { status: 500 }
+    );
+  }
+}
+
+// POST: Add a new item
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { text, project } = body as { text: string; project?: string };
+
+    if (!text || !text.trim()) {
+      return Response.json({ error: 'Text is required' }, { status: 400 });
+    }
+
+    const { items, headerLines } = readCaptures();
+    items.push({ text: text.trim(), project: project?.trim() || undefined, completed: false, source: 'captures' });
+    writeCaptures(items, headerLines);
+
+    return Response.json({ ok: true, items }, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (error) {
+    console.error('Error adding capture:', error);
+    return Response.json({ error: 'Failed to add item' }, { status: 500 });
+  }
+}
+
+// PATCH: Update an item (toggle complete, edit text, edit project)
+export async function PATCH(request: Request) {
+  try {
+    const body = await request.json();
+    const { index, completed, text, project } = body as {
+      index: number;
+      completed?: boolean;
+      text?: string;
+      project?: string | null;
+    };
+
+    if (typeof index !== 'number') {
+      return Response.json({ error: 'Index is required' }, { status: 400 });
+    }
+
+    const { items, headerLines } = readCaptures();
+
+    if (index < 0 || index >= items.length) {
+      return Response.json({ error: 'Invalid index' }, { status: 400 });
+    }
+
+    if (typeof completed === 'boolean') items[index].completed = completed;
+    if (typeof text === 'string') items[index].text = text.trim();
+    if (project === null) items[index].project = undefined;
+    else if (typeof project === 'string') items[index].project = project.trim() || undefined;
+
+    writeCaptures(items, headerLines);
+
+    return Response.json({ ok: true, items }, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (error) {
+    console.error('Error updating capture:', error);
+    return Response.json({ error: 'Failed to update item' }, { status: 500 });
+  }
+}
+
+// DELETE: Remove an item by index
+export async function DELETE(request: Request) {
+  try {
+    const body = await request.json();
+    const { index } = body as { index: number };
+
+    if (typeof index !== 'number') {
+      return Response.json({ error: 'Index is required' }, { status: 400 });
+    }
+
+    const { items, headerLines } = readCaptures();
+
+    if (index < 0 || index >= items.length) {
+      return Response.json({ error: 'Invalid index' }, { status: 400 });
+    }
+
+    items.splice(index, 1);
+    writeCaptures(items, headerLines);
+
+    return Response.json({ ok: true, items }, { headers: { 'Cache-Control': 'no-store' } });
+  } catch (error) {
+    console.error('Error deleting capture:', error);
+    return Response.json({ error: 'Failed to delete item' }, { status: 500 });
+  }
+}

--- a/src/app/cron/page.tsx
+++ b/src/app/cron/page.tsx
@@ -1,0 +1,753 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, Plus, Trash2, Pencil, Power, PowerOff, Clock, X, FileText, ChevronDown, ChevronRight } from 'lucide-react';
+
+type CronSchedule =
+  | { kind: 'at'; at: string }
+  | { kind: 'every'; everyMs: number; anchorMs?: number }
+  | { kind: 'cron'; expr: string; tz?: string };
+
+type CronPayload =
+  | { kind: 'systemEvent'; text: string }
+  | { kind: 'agentTurn'; message: string };
+
+type CronJobState = {
+  nextRunAtMs?: number;
+  runningAtMs?: number;
+  lastRunAtMs?: number;
+  lastStatus?: 'ok' | 'error' | 'skipped';
+  lastError?: string;
+  lastDurationMs?: number;
+};
+
+type CronJob = {
+  id: string;
+  name: string;
+  agentId?: string;
+  enabled: boolean;
+  updatedAtMs: number;
+  schedule: CronSchedule;
+  sessionTarget: 'main' | 'isolated';
+  wakeMode: 'next-heartbeat' | 'now';
+  payload: CronPayload;
+  state: CronJobState;
+  outputDir?: string;
+};
+
+type ReportFile = {
+  name: string;
+  size: number;
+  modified: string;
+};
+
+const POLL_INTERVAL = 20_000;
+
+const formatSchedule = (schedule: CronSchedule): string => {
+  if (schedule.kind === 'every') {
+    const ms = schedule.everyMs;
+    if (ms % 86400000 === 0) return `Every ${ms / 86400000}d`;
+    if (ms % 3600000 === 0) return `Every ${ms / 3600000}h`;
+    if (ms % 60000 === 0) return `Every ${ms / 60000}m`;
+    return `Every ${ms / 1000}s`;
+  }
+  if (schedule.kind === 'cron') {
+    return schedule.tz ? `${schedule.expr} (${schedule.tz})` : schedule.expr;
+  }
+  try {
+    return `Once: ${new Date(schedule.at).toLocaleString()}`;
+  } catch {
+    return `Once: ${schedule.at}`;
+  }
+};
+
+const formatPayload = (payload: CronPayload): string => {
+  if (payload.kind === 'systemEvent') return payload.text;
+  return payload.message;
+};
+
+const formatTime = (ms: number): string => {
+  try {
+    return new Date(ms).toLocaleString();
+  } catch {
+    return '-';
+  }
+};
+
+const formatRelativeTime = (ms: number): string => {
+  const diff = ms - Date.now();
+  if (diff < 0) return 'overdue';
+  if (diff < 60000) return `${Math.ceil(diff / 1000)}s`;
+  if (diff < 3600000) return `${Math.ceil(diff / 60000)}m`;
+  if (diff < 86400000) return `${Math.round(diff / 3600000)}h`;
+  return `${Math.round(diff / 86400000)}d`;
+};
+
+const formatFileSize = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1048576) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / 1048576).toFixed(1)}MB`;
+};
+
+const formatDate = (iso: string): string => {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+};
+
+const decomposeEveryMs = (ms: number): { amount: string; unit: 'minutes' | 'hours' | 'days' } => {
+  if (ms % 86400000 === 0) return { amount: String(ms / 86400000), unit: 'days' };
+  if (ms % 3600000 === 0) return { amount: String(ms / 3600000), unit: 'hours' };
+  if (ms % 60000 === 0) return { amount: String(ms / 60000), unit: 'minutes' };
+  return { amount: String(ms / 60000), unit: 'minutes' };
+};
+
+export default function CronPage() {
+  const [jobs, setJobs] = useState<CronJob[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Form state
+  const [showForm, setShowForm] = useState(false);
+  const [editingJobId, setEditingJobId] = useState<string | null>(null);
+  const [formName, setFormName] = useState('');
+  const [formScheduleKind, setFormScheduleKind] = useState<'every' | 'cron' | 'at'>('every');
+  const [formEveryAmount, setFormEveryAmount] = useState('1');
+  const [formEveryUnit, setFormEveryUnit] = useState<'minutes' | 'hours' | 'days'>('hours');
+  const [formCronExpr, setFormCronExpr] = useState('0 9 * * *');
+  const [formAtTime, setFormAtTime] = useState('');
+  const [formPayload, setFormPayload] = useState('');
+  const [formSessionTarget, setFormSessionTarget] = useState<'isolated' | 'main'>('isolated');
+  const [formNotifyTelegram, setFormNotifyTelegram] = useState(false);
+
+  // Reports state
+  const [expandedJobId, setExpandedJobId] = useState<string | null>(null);
+  const [reportFiles, setReportFiles] = useState<ReportFile[]>([]);
+  const [reportContent, setReportContent] = useState<{ name: string; content: string } | null>(null);
+  const [loadingReports, setLoadingReports] = useState(false);
+
+  const isEditing = editingJobId !== null;
+
+  const resetForm = () => {
+    setShowForm(false);
+    setEditingJobId(null);
+    setFormName('');
+    setFormScheduleKind('every');
+    setFormEveryAmount('1');
+    setFormEveryUnit('hours');
+    setFormCronExpr('0 9 * * *');
+    setFormAtTime('');
+    setFormPayload('');
+    setFormSessionTarget('isolated');
+    setFormNotifyTelegram(false);
+  };
+
+  const openAddForm = () => {
+    resetForm();
+    setShowForm(true);
+  };
+
+  const openEditForm = (job: CronJob) => {
+    setEditingJobId(job.id);
+    setFormName(job.name);
+    setFormSessionTarget(job.sessionTarget);
+    setFormPayload(formatPayload(job.payload));
+    setFormNotifyTelegram((job as CronJob & { delivery?: { mode: string } }).delivery?.mode === 'announce');
+
+    if (job.schedule.kind === 'every') {
+      setFormScheduleKind('every');
+      const { amount, unit } = decomposeEveryMs(job.schedule.everyMs);
+      setFormEveryAmount(amount);
+      setFormEveryUnit(unit);
+    } else if (job.schedule.kind === 'cron') {
+      setFormScheduleKind('cron');
+      setFormCronExpr(job.schedule.expr);
+    } else {
+      setFormScheduleKind('at');
+      try {
+        setFormAtTime(new Date(job.schedule.at).toISOString().slice(0, 16));
+      } catch {
+        setFormAtTime('');
+      }
+    }
+
+    setShowForm(true);
+  };
+
+  const fetchJobs = useCallback(async () => {
+    try {
+      const response = await fetch('/api/cron');
+      if (!response.ok) throw new Error('Failed to fetch cron jobs');
+      const result = await response.json();
+      setJobs(result.jobs || []);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchJobs();
+    const interval = setInterval(fetchJobs, POLL_INTERVAL);
+    const handleVisibility = () => { if (!document.hidden) fetchJobs(); };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [fetchJobs]);
+
+  const toggleReports = async (job: CronJob) => {
+    if (expandedJobId === job.id) {
+      setExpandedJobId(null);
+      setReportFiles([]);
+      setReportContent(null);
+      return;
+    }
+
+    if (!job.outputDir) return;
+
+    setExpandedJobId(job.id);
+    setReportContent(null);
+    setLoadingReports(true);
+
+    try {
+      const res = await fetch(`/api/cron/reports?dir=${encodeURIComponent(job.outputDir)}`);
+      if (res.ok) {
+        const data = await res.json();
+        setReportFiles(data.files || []);
+      }
+    } catch (err) {
+      console.error('Failed to load reports:', err);
+    } finally {
+      setLoadingReports(false);
+    }
+  };
+
+  const openReport = async (outputDir: string, fileName: string) => {
+    try {
+      const res = await fetch(`/api/cron/reports?dir=${encodeURIComponent(outputDir)}&file=${encodeURIComponent(fileName)}`);
+      if (res.ok) {
+        const data = await res.json();
+        setReportContent({ name: data.name, content: data.content });
+      }
+    } catch (err) {
+      console.error('Failed to read report:', err);
+    }
+  };
+
+  const buildSchedule = (): CronSchedule => {
+    if (formScheduleKind === 'every') {
+      const multiplier = formEveryUnit === 'minutes' ? 60000 :
+                        formEveryUnit === 'hours' ? 3600000 : 86400000;
+      return { kind: 'every', everyMs: parseInt(formEveryAmount, 10) * multiplier };
+    }
+    if (formScheduleKind === 'cron') {
+      return { kind: 'cron', expr: formCronExpr.trim() };
+    }
+    return { kind: 'at', at: new Date(formAtTime).toISOString() };
+  };
+
+  const buildPayload = (): CronPayload => {
+    if (formSessionTarget === 'main') {
+      return { kind: 'systemEvent', text: formPayload.trim() };
+    }
+    return { kind: 'agentTurn', message: formPayload.trim() };
+  };
+
+  const handleToggle = async (id: string) => {
+    setBusy(true);
+    try {
+      const res = await fetch('/api/cron', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'toggle', id }),
+      });
+      if (res.ok) {
+        const { jobs: updatedJobs } = await res.json();
+        setJobs(updatedJobs);
+      }
+    } catch (err) {
+      console.error('Toggle failed:', err);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleRemove = async (id: string) => {
+    setBusy(true);
+    try {
+      const res = await fetch('/api/cron', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'remove', id }),
+      });
+      if (res.ok) {
+        const { jobs: updatedJobs } = await res.json();
+        setJobs(updatedJobs);
+      }
+    } catch (err) {
+      console.error('Remove failed:', err);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleSubmit = async () => {
+    if (!formName.trim() || !formPayload.trim()) return;
+    setBusy(true);
+    try {
+      const schedule = buildSchedule();
+      const payload = buildPayload();
+
+      const delivery = formNotifyTelegram
+        ? { mode: 'announce' as const, channel: 'last' }
+        : { mode: 'none' as const };
+
+      if (isEditing) {
+        const res = await fetch('/api/cron', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            action: 'update',
+            id: editingJobId,
+            name: formName.trim(),
+            schedule,
+            payload,
+            delivery,
+          }),
+        });
+        if (res.ok) {
+          const { jobs: updatedJobs } = await res.json();
+          setJobs(updatedJobs);
+          resetForm();
+        }
+      } else {
+        const res = await fetch('/api/cron', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            action: 'add',
+            name: formName.trim(),
+            schedule,
+            payload,
+            sessionTarget: formSessionTarget,
+            wakeMode: 'now',
+            delivery,
+          }),
+        });
+        if (res.ok) {
+          const { jobs: updatedJobs } = await res.json();
+          setJobs(updatedJobs);
+          resetForm();
+        }
+      }
+    } catch (err) {
+      console.error('Submit failed:', err);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4" />
+          <p className="text-muted-foreground">Loading cron jobs...</p>
+        </div>
+      </div>
+    );
+  }
+
+  const enabledCount = jobs.filter(j => j.enabled).length;
+  const disabledCount = jobs.filter(j => !j.enabled).length;
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      {/* Header */}
+      <div className="glass-panel fade-up ui-panel ui-topbar relative z-[180] px-3.5 py-3 border-b">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Link href="/" className="hover:opacity-70 transition">
+              <ArrowLeft className="w-5 h-5" />
+            </Link>
+            <h1 className="console-title type-page-title">Scheduled Jobs</h1>
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="text-xs text-muted-foreground">
+              {enabledCount} active / {disabledCount} disabled
+            </div>
+            <button
+              type="button"
+              className="ui-btn-primary px-3 py-1.5 text-xs font-medium flex items-center gap-1.5"
+              onClick={openAddForm}
+            >
+              <Plus className="w-3.5 h-3.5" />
+              Add Job
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto p-6">
+        <div className="max-w-4xl mx-auto space-y-4">
+          {error && (
+            <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-4">
+              <p className="text-destructive">Error: {error}</p>
+            </div>
+          )}
+
+          {/* Add/Edit Form */}
+          {showForm && (
+            <div className="ui-panel p-4 space-y-3">
+              <div className="flex items-center justify-between mb-2">
+                <h3 className="text-sm font-semibold">
+                  {isEditing ? 'Edit Job' : 'New Scheduled Job'}
+                </h3>
+                <button
+                  type="button"
+                  className="ui-btn-icon h-7 w-7 !bg-transparent hover:!bg-muted"
+                  onClick={resetForm}
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+
+              <input
+                type="text"
+                className="ui-input w-full rounded-md px-3 py-2 text-sm"
+                placeholder="Job name (e.g., Morning Brief)"
+                value={formName}
+                onChange={e => setFormName(e.target.value)}
+              />
+
+              <div>
+                <label className="text-xs text-muted-foreground mb-1 block">Schedule</label>
+                <div className="ui-segment grid-cols-3" style={{ display: 'inline-grid' }}>
+                  {(['every', 'cron', 'at'] as const).map(kind => (
+                    <button
+                      key={kind}
+                      type="button"
+                      className="ui-segment-item px-3 py-1.5 text-[12px] font-medium capitalize"
+                      data-active={formScheduleKind === kind ? 'true' : 'false'}
+                      onClick={() => setFormScheduleKind(kind)}
+                    >
+                      {kind === 'every' ? 'Interval' : kind === 'cron' ? 'Cron Expr' : 'One-time'}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {formScheduleKind === 'every' && (
+                <div className="flex gap-2 items-center">
+                  <span className="text-xs text-muted-foreground">Every</span>
+                  <input
+                    type="number"
+                    className="ui-input w-20 rounded-md px-2 py-1.5 text-sm"
+                    min="1"
+                    value={formEveryAmount}
+                    onChange={e => setFormEveryAmount(e.target.value)}
+                  />
+                  <select
+                    className="ui-input rounded-md px-2 py-1.5 text-xs"
+                    value={formEveryUnit}
+                    onChange={e => setFormEveryUnit(e.target.value as 'minutes' | 'hours' | 'days')}
+                  >
+                    <option value="minutes">minutes</option>
+                    <option value="hours">hours</option>
+                    <option value="days">days</option>
+                  </select>
+                </div>
+              )}
+              {formScheduleKind === 'cron' && (
+                <input
+                  type="text"
+                  className="ui-input w-full rounded-md px-3 py-2 text-sm font-mono"
+                  placeholder="0 9 * * * (min hour dom mon dow)"
+                  value={formCronExpr}
+                  onChange={e => setFormCronExpr(e.target.value)}
+                />
+              )}
+              {formScheduleKind === 'at' && (
+                <input
+                  type="datetime-local"
+                  className="ui-input w-full rounded-md px-3 py-2 text-sm"
+                  value={formAtTime}
+                  onChange={e => setFormAtTime(e.target.value)}
+                />
+              )}
+
+              {!isEditing && (
+                <div>
+                  <label className="text-xs text-muted-foreground mb-1 block">Session</label>
+                  <div className="ui-segment grid-cols-2" style={{ display: 'inline-grid' }}>
+                    {(['isolated', 'main'] as const).map(target => (
+                      <button
+                        key={target}
+                        type="button"
+                        className="ui-segment-item px-3 py-1.5 text-[12px] font-medium capitalize"
+                        data-active={formSessionTarget === target ? 'true' : 'false'}
+                        onClick={() => setFormSessionTarget(target)}
+                      >
+                        {target}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Telegram notification */}
+              <label className="flex items-center gap-2.5 cursor-pointer">
+                <button
+                  type="button"
+                  className={`flex-shrink-0 h-5 w-9 rounded-full transition-colors relative ${
+                    formNotifyTelegram ? 'bg-primary' : 'bg-muted'
+                  }`}
+                  onClick={() => setFormNotifyTelegram(v => !v)}
+                >
+                  <span className={`absolute top-0.5 h-4 w-4 rounded-full bg-white shadow transition-transform ${
+                    formNotifyTelegram ? 'translate-x-4' : 'translate-x-0.5'
+                  }`} />
+                </button>
+                <span className="text-xs text-muted-foreground">
+                  Notify via Telegram when complete
+                </span>
+              </label>
+
+              <textarea
+                className="ui-input w-full rounded-md px-3 py-2 text-sm min-h-[80px] resize-y"
+                placeholder="Task/prompt for the agent..."
+                value={formPayload}
+                onChange={e => setFormPayload(e.target.value)}
+              />
+
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  className="ui-btn-primary px-4 py-1.5 text-xs font-medium"
+                  onClick={handleSubmit}
+                  disabled={busy || !formName.trim() || !formPayload.trim()}
+                >
+                  {isEditing ? 'Save Changes' : 'Create Job'}
+                </button>
+                <button
+                  type="button"
+                  className="ui-btn-secondary px-4 py-1.5 text-xs font-medium"
+                  onClick={resetForm}
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Report Viewer Modal */}
+          {reportContent && (
+            <div className="ui-panel p-4">
+              <div className="flex items-center justify-between mb-3">
+                <div className="flex items-center gap-2">
+                  <FileText className="w-4 h-4 text-primary" />
+                  <h3 className="text-sm font-semibold">{reportContent.name}</h3>
+                </div>
+                <button
+                  type="button"
+                  className="ui-btn-icon h-7 w-7 !bg-transparent hover:!bg-muted"
+                  onClick={() => setReportContent(null)}
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+              <pre className="bg-muted/30 border border-border rounded-md p-4 text-xs font-mono overflow-auto max-h-[500px] whitespace-pre-wrap">
+                {reportContent.content}
+              </pre>
+            </div>
+          )}
+
+          {/* Jobs list */}
+          {jobs.length === 0 ? (
+            <div className="ui-panel p-8 text-center text-muted-foreground text-sm">
+              No scheduled jobs. Create one above or use <code className="bg-muted px-1 rounded text-xs">openclaw cron add</code> via CLI.
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {[...jobs].sort((a, b) => b.updatedAtMs - a.updatedAtMs).map(job => {
+                const isExpanded = expandedJobId === job.id;
+                const hasOutputDir = !!job.outputDir;
+
+                return (
+                  <div
+                    key={job.id}
+                    className={`ui-panel border-l-4 transition-opacity ${
+                      job.enabled
+                        ? 'border-green-500/50'
+                        : 'border-muted opacity-60'
+                    } ${busy ? 'pointer-events-none' : ''}`}
+                  >
+                    <div className="flex items-start justify-between px-4 py-3 group">
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <p className="font-semibold text-sm">{job.name}</p>
+                          {job.enabled ? (
+                            <span className="inline-flex items-center gap-1 rounded-md bg-green-500/15 px-1.5 py-0.5 text-[10px] font-semibold text-green-700 dark:text-green-400">
+                              <span className="inline-block h-1.5 w-1.5 rounded-full bg-green-500" />
+                              active
+                            </span>
+                          ) : (
+                            <span className="inline-flex rounded-md bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                              disabled
+                            </span>
+                          )}
+                          {(job as CronJob & { delivery?: { mode: string } }).delivery?.mode === 'announce' && (
+                          <span className="inline-flex items-center gap-1 rounded-md bg-blue-500/15 px-1.5 py-0.5 text-[10px] font-medium text-blue-700 dark:text-blue-400">
+                            TG
+                          </span>
+                        )}
+                        {job.state.lastStatus === 'error' && (
+                            <span className="inline-flex rounded-md bg-destructive/15 px-1.5 py-0.5 text-[10px] font-medium text-destructive">
+                              error
+                            </span>
+                          )}
+                        </div>
+
+                        <div className="flex items-center gap-1.5 mt-1">
+                          <Clock className="w-3 h-3 text-muted-foreground" />
+                          <p className="text-xs text-muted-foreground font-mono">
+                            {formatSchedule(job.schedule)}
+                          </p>
+                        </div>
+
+                        <p className="text-xs text-muted-foreground mt-1 truncate max-w-md">
+                          {formatPayload(job.payload)}
+                        </p>
+
+                        <div className="flex items-center gap-4 mt-1.5">
+                          {job.state.nextRunAtMs && (
+                            <span className="text-[10px] text-muted-foreground">
+                              Next: {formatRelativeTime(job.state.nextRunAtMs)}
+                            </span>
+                          )}
+                          {job.state.lastRunAtMs && (
+                            <span className="text-[10px] text-muted-foreground">
+                              Last: {formatTime(job.state.lastRunAtMs)}
+                              {job.state.lastDurationMs != null && ` (${Math.round(job.state.lastDurationMs / 1000)}s)`}
+                            </span>
+                          )}
+                          {job.state.lastError && (
+                            <span className="text-[10px] text-destructive truncate max-w-48" title={job.state.lastError}>
+                              {job.state.lastError}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+
+                      {/* Actions */}
+                      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                        {hasOutputDir && (
+                          <button
+                            type="button"
+                            className={`ui-btn-icon h-7 w-7 !bg-transparent hover:!bg-primary/10 ${isExpanded ? 'text-primary' : 'text-muted-foreground hover:!text-primary'}`}
+                            onClick={() => toggleReports(job)}
+                            title="View Reports"
+                          >
+                            <FileText className="w-3.5 h-3.5" />
+                          </button>
+                        )}
+                        <button
+                          type="button"
+                          className="ui-btn-icon h-7 w-7 !bg-transparent hover:!bg-muted"
+                          onClick={() => openEditForm(job)}
+                          title="Edit"
+                        >
+                          <Pencil className="w-3.5 h-3.5" />
+                        </button>
+                        <button
+                          type="button"
+                          className="ui-btn-icon h-7 w-7 !bg-transparent hover:!bg-muted"
+                          onClick={() => handleToggle(job.id)}
+                          title={job.enabled ? 'Disable' : 'Enable'}
+                        >
+                          {job.enabled ? (
+                            <PowerOff className="w-3.5 h-3.5" />
+                          ) : (
+                            <Power className="w-3.5 h-3.5 text-green-600" />
+                          )}
+                        </button>
+                        <button
+                          type="button"
+                          className="ui-btn-icon h-7 w-7 !bg-transparent hover:!bg-destructive/10 text-muted-foreground hover:!text-destructive"
+                          onClick={() => handleRemove(job.id)}
+                          title="Delete"
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </button>
+                      </div>
+                    </div>
+
+                    {/* Expanded Reports Section */}
+                    {isExpanded && hasOutputDir && (
+                      <div className="border-t border-border px-4 pb-3 pt-2">
+                        <div className="flex items-center gap-2 mb-2">
+                          <FileText className="w-3.5 h-3.5 text-muted-foreground" />
+                          <p className="text-xs font-semibold text-muted-foreground">Output Files</p>
+                        </div>
+
+                        {loadingReports ? (
+                          <div className="text-xs text-muted-foreground py-2">Loading...</div>
+                        ) : reportFiles.length === 0 ? (
+                          <div className="text-xs text-muted-foreground py-2">No output files yet. Reports will appear here after the job runs.</div>
+                        ) : (
+                          <div className="space-y-1">
+                            {reportFiles.map(file => (
+                              <button
+                                key={file.name}
+                                type="button"
+                                className="flex items-center justify-between w-full text-left px-3 py-2 rounded-md hover:bg-muted/50 transition group/file"
+                                onClick={() => openReport(job.outputDir!, file.name)}
+                              >
+                                <div className="flex items-center gap-2 min-w-0">
+                                  <FileText className="w-3.5 h-3.5 text-primary flex-shrink-0" />
+                                  <span className="text-xs font-medium truncate">{file.name}</span>
+                                </div>
+                                <div className="flex items-center gap-3 flex-shrink-0">
+                                  <span className="text-[10px] text-muted-foreground">
+                                    {formatFileSize(file.size)}
+                                  </span>
+                                  <span className="text-[10px] text-muted-foreground">
+                                    {formatDate(file.modified)}
+                                  </span>
+                                  <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover/file:opacity-100" />
+                                </div>
+                              </button>
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {/* Refresh */}
+          <div className="flex justify-center">
+            <button
+              onClick={fetchJobs}
+              className="px-4 py-2 rounded-lg bg-primary text-primary-foreground hover:opacity-90 transition text-sm"
+            >
+              Refresh Now
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1287,3 +1287,17 @@ textarea:focus::-webkit-scrollbar {
     transform: translateY(-1px);
   }
 }
+
+@keyframes sessionNeedsInputPulse {
+  0%, 100% {
+    border-left-color: color-mix(in oklch, #ca8a04 60%, transparent);
+  }
+  50% {
+    border-left-color: color-mix(in oklch, #ca8a04 100%, transparent);
+  }
+}
+
+.session-needs-input {
+  border-left: 3px solid #ca8a04;
+  animation: sessionNeedsInputPulse 2s ease-in-out infinite;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,9 @@ import {
 } from "@/features/agents/components/AgentInspectPanels";
 import { FleetSidebar } from "@/features/agents/components/FleetSidebar";
 import { HeaderBar } from "@/features/agents/components/HeaderBar";
+import { SessionsWidget } from "@/components/SessionsWidget";
+import { TodosWidget } from "@/components/TodosWidget";
+import { CronWidget } from "@/components/CronWidget";
 import { ConnectionPanel } from "@/features/agents/components/ConnectionPanel";
 import { GatewayConnectScreen } from "@/features/agents/components/GatewayConnectScreen";
 import { EmptyStatePanel } from "@/features/agents/components/EmptyStatePanel";
@@ -2298,6 +2301,10 @@ const AgentStudioPage = () => {
             </div>
           </div>
         ) : null}
+
+        <SessionsWidget />
+        <TodosWidget />
+        <CronWidget />
 
         <div className="flex min-h-0 flex-1 flex-col gap-4 xl:flex-row">
           <div className="glass-panel ui-panel p-2 xl:hidden" data-testid="mobile-pane-toggle">

--- a/src/app/sessions/page.tsx
+++ b/src/app/sessions/page.tsx
@@ -1,0 +1,267 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import type { Session, SessionsData } from '@/types/sessions';
+
+const POLL_INTERVAL = 20_000;
+
+const formatTime = (timestamp: string) => {
+  try {
+    const date = new Date(timestamp);
+    return date.toLocaleString();
+  } catch {
+    return timestamp;
+  }
+};
+
+const getElapsedTime = (startTime: string, endTime?: string) => {
+  try {
+    const start = new Date(startTime);
+    const end = endTime ? new Date(endTime) : new Date();
+    const diffMs = end.getTime() - start.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMins / 60);
+
+    if (diffHours > 0) {
+      return `${diffHours}h ${diffMins % 60}m`;
+    }
+    return `${diffMins}m`;
+  } catch {
+    return '-';
+  }
+};
+
+export default function SessionsPage() {
+  const [data, setData] = useState<SessionsData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchSessions = useCallback(async () => {
+    try {
+      const response = await fetch('/api/sessions');
+      if (!response.ok) throw new Error('Failed to fetch sessions');
+      const result: SessionsData = await response.json();
+      setData(result);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSessions();
+
+    const interval = setInterval(fetchSessions, POLL_INTERVAL);
+
+    const handleVisibilityChange = () => {
+      if (!document.hidden) {
+        fetchSessions();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [fetchSessions]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4"></div>
+          <p className="text-muted-foreground">Loading sessions...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      {/* Header - matching studio style */}
+      <div className="glass-panel fade-up ui-panel ui-topbar relative z-[180] px-3.5 py-3 border-b">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Link href="/" className="hover:opacity-70 transition">
+              <ArrowLeft className="w-5 h-5" />
+            </Link>
+            <h1 className="console-title type-page-title">Claude Code Sessions</h1>
+          </div>
+          <div className="text-xs text-muted-foreground">
+            Last updated: {data?.lastUpdated ? formatTime(data.lastUpdated) : 'never'}
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto p-6">
+        <div className="max-w-6xl mx-auto space-y-6">
+          {error && (
+            <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-4">
+              <p className="text-destructive">Error: {error}</p>
+            </div>
+          )}
+
+          {/* Active Sessions */}
+          <div>
+            <h2 className="text-lg font-semibold mb-3">
+              Active Sessions ({data?.active.length || 0})
+            </h2>
+            {data?.active && data.active.length > 0 ? (
+              <div className="grid gap-3">
+                {data.active.map((session) => (
+                  <div
+                    key={session.project}
+                    className="glass-panel ui-panel border-l-4 border-green-500/50 p-4"
+                  >
+                    <div className="flex items-start justify-between">
+                      <div className="flex-1">
+                        <p className="font-semibold">{session.project}</p>
+                        {session.details && (
+                          <p className="text-xs text-muted-foreground mt-1">{session.details}</p>
+                        )}
+                        <p className="text-xs text-muted-foreground mt-1">
+                          Started: {formatTime(session.startTime)}
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          Running for: {getElapsedTime(session.startTime)}
+                        </p>
+                      </div>
+                      <div className="animate-pulse bg-green-500/50 rounded-full h-3 w-3"></div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="glass-panel ui-panel p-4 text-muted-foreground text-sm">
+                No active sessions
+              </div>
+            )}
+          </div>
+
+          {/* Paused Sessions - NEEDS INPUT */}
+          <div>
+            <h2 className="text-lg font-semibold mb-3">
+              Paused - Needs Your Input ({data?.paused.length || 0})
+            </h2>
+            {data?.paused && data.paused.length > 0 ? (
+              <div className="grid gap-3">
+                {data.paused.map((session) => (
+                  <div
+                    key={session.project}
+                    className="glass-panel ui-panel border-l-4 border-yellow-500/50 p-4 session-needs-input"
+                  >
+                    <div className="flex items-start justify-between">
+                      <div className="flex-1">
+                        <p className="font-semibold">{session.project}</p>
+                        {session.details && (
+                          <p className="text-xs text-yellow-700 dark:text-yellow-400 mt-1 font-medium">
+                            {session.details}
+                          </p>
+                        )}
+                        <p className="text-xs text-muted-foreground mt-1">
+                          Started: {formatTime(session.startTime)}
+                        </p>
+                      </div>
+                      <div className="animate-pulse bg-yellow-500/50 rounded-full h-3 w-3"></div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="glass-panel ui-panel p-4 text-muted-foreground text-sm">
+                No paused sessions
+              </div>
+            )}
+          </div>
+
+          {/* Interrupted Sessions */}
+          <div>
+            <h2 className="text-lg font-semibold mb-3">
+              Interrupted ({data?.exited.length || 0})
+            </h2>
+            {data?.exited && data.exited.length > 0 ? (
+              <div className="grid gap-3">
+                {data.exited.map((session) => (
+                  <div
+                    key={`${session.project}-exited`}
+                    className="glass-panel ui-panel border-l-4 border-orange-500/50 p-4"
+                  >
+                    <div className="flex items-start justify-between">
+                      <div className="flex-1">
+                        <p className="font-semibold">{session.project}</p>
+                        {session.details && (
+                          <p className="text-xs text-muted-foreground mt-1">{session.details}</p>
+                        )}
+                        <p className="text-xs text-muted-foreground">
+                          Ended: {session.endTime ? formatTime(session.endTime) : 'N/A'}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="glass-panel ui-panel p-4 text-muted-foreground text-sm">
+                No interrupted sessions
+              </div>
+            )}
+          </div>
+
+          {/* Completed Sessions */}
+          <div>
+            <h2 className="text-lg font-semibold mb-3">
+              Completed Sessions ({data?.completed.length || 0})
+            </h2>
+            {data?.completed && data.completed.length > 0 ? (
+              <div className="grid gap-3">
+                {data.completed.map((session) => (
+                  <div
+                    key={`${session.project}-${session.endTime}`}
+                    className="glass-panel ui-panel p-4"
+                  >
+                    <div className="flex items-start justify-between">
+                      <div className="flex-1">
+                        <p className="font-semibold">{session.project}</p>
+                        {session.details && (
+                          <p className="text-xs text-muted-foreground mt-1">{session.details}</p>
+                        )}
+                        <p className="text-xs text-muted-foreground mt-1">
+                          Started: {formatTime(session.startTime)}
+                        </p>
+                        {session.endTime && (
+                          <p className="text-xs text-muted-foreground">
+                            Duration: {getElapsedTime(session.startTime, session.endTime)}
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="glass-panel ui-panel p-4 text-muted-foreground text-sm">
+                No completed sessions yet
+              </div>
+            )}
+          </div>
+
+          {/* Refresh button */}
+          <div className="flex justify-center">
+            <button
+              onClick={fetchSessions}
+              className="px-4 py-2 rounded-lg bg-primary text-primary-foreground hover:opacity-90 transition text-sm"
+            >
+              Refresh Now
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/todos/page.tsx
+++ b/src/app/todos/page.tsx
@@ -1,0 +1,528 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, Plus, Trash2, Pencil, Check, X, Tag, Zap, Loader2 } from 'lucide-react';
+import type { TodoItem, TodosData } from '@/types/todos';
+
+type Assignment = {
+  id: string;
+  todoIndex: number;
+  todoText: string;
+  project: string;
+  status: 'in_progress' | 'completed' | 'failed';
+  startedAt: string;
+  completedAt: string | null;
+  error: string | null;
+};
+
+const POLL_INTERVAL = 30_000;
+
+const formatTime = (timestamp: string) => {
+  try {
+    return new Date(timestamp).toLocaleString();
+  } catch {
+    return timestamp;
+  }
+};
+
+export default function TodosPage() {
+  const [data, setData] = useState<TodosData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [filter, setFilter] = useState<'all' | 'pending' | 'completed'>('all');
+  const [projectFilter, setProjectFilter] = useState<string | null>(null);
+
+  // Add form state
+  const [newText, setNewText] = useState('');
+  const [newProject, setNewProject] = useState('');
+  const [showAddForm, setShowAddForm] = useState(false);
+  const addInputRef = useRef<HTMLInputElement>(null);
+
+  // Edit state
+  const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [editText, setEditText] = useState('');
+  const [editProject, setEditProject] = useState('');
+  const editInputRef = useRef<HTMLInputElement>(null);
+
+  // Busy state for optimistic updates
+  const [busy, setBusy] = useState(false);
+
+  // Assignment state
+  const [assignments, setAssignments] = useState<Assignment[]>([]);
+  const [assigningIndex, setAssigningIndex] = useState<number | null>(null);
+
+  const fetchAssignments = useCallback(async () => {
+    try {
+      const response = await fetch('/api/assign');
+      if (response.ok) {
+        const result = await response.json();
+        setAssignments(result.assignments || []);
+      }
+    } catch {
+      // Assignments are optional
+    }
+  }, []);
+
+  const handleAssign = async (todoIndex: number) => {
+    setAssigningIndex(todoIndex);
+    try {
+      const res = await fetch('/api/assign', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ todoIndex: todoIndex + 1 }), // assign-todo.js uses 1-based
+      });
+      const result = await res.json();
+      if (res.ok) {
+        await fetchAssignments();
+      } else {
+        console.error('Assign failed:', result.error);
+      }
+    } catch (err) {
+      console.error('Assign failed:', err);
+    } finally {
+      setAssigningIndex(null);
+    }
+  };
+
+  const getAssignment = (index: number): Assignment | undefined => {
+    // assign-todo.js uses 1-based indexing
+    return assignments.find(a => a.todoIndex === index + 1 && a.status === 'in_progress');
+  };
+
+  const fetchTodos = useCallback(async () => {
+    try {
+      const response = await fetch('/api/todos');
+      if (!response.ok) throw new Error('Failed to fetch todos');
+      const result: TodosData = await response.json();
+      setData(result);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchTodos();
+    fetchAssignments();
+    const interval = setInterval(() => { fetchTodos(); fetchAssignments(); }, POLL_INTERVAL);
+    const handleVisibility = () => { if (!document.hidden) { fetchTodos(); fetchAssignments(); } };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [fetchTodos, fetchAssignments]);
+
+  useEffect(() => {
+    if (showAddForm && addInputRef.current) addInputRef.current.focus();
+  }, [showAddForm]);
+
+  useEffect(() => {
+    if (editingIndex !== null && editInputRef.current) editInputRef.current.focus();
+  }, [editingIndex]);
+
+  const handleToggle = async (index: number, currentCompleted: boolean) => {
+    setBusy(true);
+    try {
+      const res = await fetch('/api/todos', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ index, completed: !currentCompleted }),
+      });
+      if (res.ok) {
+        const { items } = await res.json();
+        setData((prev) => prev ? { ...prev, items } : prev);
+      }
+    } catch (err) {
+      console.error('Toggle failed:', err);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleAdd = async () => {
+    if (!newText.trim()) return;
+    setBusy(true);
+    try {
+      const res = await fetch('/api/todos', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: newText.trim(), project: newProject.trim() || undefined }),
+      });
+      if (res.ok) {
+        const { items } = await res.json();
+        setData((prev) => prev ? { ...prev, items } : prev);
+        setNewText('');
+        setNewProject('');
+        setShowAddForm(false);
+      }
+    } catch (err) {
+      console.error('Add failed:', err);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDelete = async (index: number) => {
+    setBusy(true);
+    try {
+      const res = await fetch('/api/todos', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ index }),
+      });
+      if (res.ok) {
+        const { items } = await res.json();
+        setData((prev) => prev ? { ...prev, items } : prev);
+      }
+    } catch (err) {
+      console.error('Delete failed:', err);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleEditStart = (index: number, item: TodoItem) => {
+    setEditingIndex(index);
+    setEditText(item.text);
+    setEditProject(item.project || '');
+  };
+
+  const handleEditSave = async () => {
+    if (editingIndex === null || !editText.trim()) return;
+    setBusy(true);
+    try {
+      const res = await fetch('/api/todos', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          index: editingIndex,
+          text: editText.trim(),
+          project: editProject.trim() || null,
+        }),
+      });
+      if (res.ok) {
+        const { items } = await res.json();
+        setData((prev) => prev ? { ...prev, items } : prev);
+        setEditingIndex(null);
+      }
+    } catch (err) {
+      console.error('Edit failed:', err);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleEditCancel = () => {
+    setEditingIndex(null);
+    setEditText('');
+    setEditProject('');
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-primary mx-auto mb-4" />
+          <p className="text-muted-foreground">Loading captures...</p>
+        </div>
+      </div>
+    );
+  }
+
+  const allItems = data?.items ?? [];
+
+  // Get unique projects for filter
+  const projects = [...new Set(allItems.filter((i) => i.project).map((i) => i.project!))];
+
+  // Apply filters
+  let filtered = allItems.map((item, i) => ({ ...item, originalIndex: i }));
+  if (filter === 'pending') filtered = filtered.filter((i) => !i.completed);
+  if (filter === 'completed') filtered = filtered.filter((i) => i.completed);
+  if (projectFilter === '__personal') filtered = filtered.filter((i) => !i.project);
+  else if (projectFilter) filtered = filtered.filter((i) => i.project === projectFilter);
+
+  const pendingCount = allItems.filter((i) => !i.completed).length;
+  const completedCount = allItems.filter((i) => i.completed).length;
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      {/* Header */}
+      <div className="glass-panel fade-up ui-panel ui-topbar relative z-[180] px-3.5 py-3 border-b">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Link href="/" className="hover:opacity-70 transition">
+              <ArrowLeft className="w-5 h-5" />
+            </Link>
+            <h1 className="console-title type-page-title">Captures & TODOs</h1>
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="text-xs text-muted-foreground">
+              {pendingCount} pending / {completedCount} done
+            </div>
+            <div className="text-xs text-muted-foreground">
+              Updated: {data?.lastUpdated ? formatTime(data.lastUpdated) : 'never'}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto p-6">
+        <div className="max-w-4xl mx-auto space-y-4">
+          {error && (
+            <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-4">
+              <p className="text-destructive">Error: {error}</p>
+            </div>
+          )}
+
+          {/* Toolbar */}
+          <div className="flex items-center justify-between gap-3 flex-wrap">
+            {/* Status filter */}
+            <div className="flex items-center gap-1">
+              <div className="ui-segment grid-cols-3" style={{ display: 'inline-grid' }}>
+                {(['all', 'pending', 'completed'] as const).map((f) => (
+                  <button
+                    key={f}
+                    type="button"
+                    className="ui-segment-item px-3 py-1.5 text-[12px] font-medium capitalize"
+                    data-active={filter === f ? 'true' : 'false'}
+                    onClick={() => setFilter(f)}
+                  >
+                    {f} {f === 'pending' ? `(${pendingCount})` : f === 'completed' ? `(${completedCount})` : `(${allItems.length})`}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2">
+              {/* Project filter */}
+              {projects.length > 0 && (
+                <select
+                  className="ui-input rounded-md px-2 py-1.5 text-xs"
+                  value={projectFilter || ''}
+                  onChange={(e) => setProjectFilter(e.target.value || null)}
+                >
+                  <option value="">All projects</option>
+                  <option value="__personal">Personal (no project)</option>
+                  {projects.map((p) => (
+                    <option key={p} value={p}>{p}</option>
+                  ))}
+                </select>
+              )}
+
+              {/* Add button */}
+              <button
+                type="button"
+                className="ui-btn-primary px-3 py-1.5 text-xs font-medium flex items-center gap-1.5"
+                onClick={() => setShowAddForm((v) => !v)}
+              >
+                <Plus className="w-3.5 h-3.5" />
+                Add Item
+              </button>
+            </div>
+          </div>
+
+          {/* Add form */}
+          {showAddForm && (
+            <div className="ui-panel p-4 space-y-3">
+              <div className="flex gap-2">
+                <input
+                  ref={addInputRef}
+                  type="text"
+                  className="ui-input flex-1 rounded-md px-3 py-2 text-sm"
+                  placeholder="What needs to be done?"
+                  value={newText}
+                  onChange={(e) => setNewText(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleAdd();
+                    if (e.key === 'Escape') setShowAddForm(false);
+                  }}
+                />
+                <div className="flex items-center gap-1">
+                  <Tag className="w-3.5 h-3.5 text-muted-foreground" />
+                  <input
+                    type="text"
+                    className="ui-input w-36 rounded-md px-2 py-2 text-sm"
+                    placeholder="Project (optional)"
+                    value={newProject}
+                    onChange={(e) => setNewProject(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') handleAdd();
+                      if (e.key === 'Escape') setShowAddForm(false);
+                    }}
+                  />
+                </div>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  className="ui-btn-primary px-4 py-1.5 text-xs font-medium"
+                  onClick={handleAdd}
+                  disabled={busy || !newText.trim()}
+                >
+                  Add
+                </button>
+                <button
+                  type="button"
+                  className="ui-btn-secondary px-4 py-1.5 text-xs font-medium"
+                  onClick={() => { setShowAddForm(false); setNewText(''); setNewProject(''); }}
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Items list */}
+          {filtered.length === 0 ? (
+            <div className="ui-panel p-8 text-center text-muted-foreground text-sm">
+              {allItems.length === 0
+                ? 'No captures yet. Add one above or send via Telegram.'
+                : 'No items match the current filter.'}
+            </div>
+          ) : (
+            <div className="space-y-1.5">
+              {filtered.map((item) => {
+                const idx = item.originalIndex;
+                const isEditing = editingIndex === idx;
+
+                return (
+                  <div
+                    key={idx}
+                    className={`ui-panel flex items-start gap-3 px-4 py-3 group transition-opacity ${
+                      item.completed ? 'opacity-50' : ''
+                    } ${busy ? 'pointer-events-none' : ''}`}
+                  >
+                    {/* Checkbox */}
+                    <button
+                      type="button"
+                      className={`mt-0.5 flex-shrink-0 h-5 w-5 rounded border-2 flex items-center justify-center transition-colors ${
+                        item.completed
+                          ? 'bg-primary/20 border-primary/40 text-primary'
+                          : 'border-border hover:border-primary/50'
+                      }`}
+                      onClick={() => handleToggle(idx, item.completed)}
+                    >
+                      {item.completed && <Check className="w-3 h-3" />}
+                    </button>
+
+                    {/* Content */}
+                    <div className="flex-1 min-w-0">
+                      {isEditing ? (
+                        <div className="space-y-2">
+                          <input
+                            ref={editInputRef}
+                            type="text"
+                            className="ui-input w-full rounded-md px-2 py-1.5 text-sm"
+                            value={editText}
+                            onChange={(e) => setEditText(e.target.value)}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter') handleEditSave();
+                              if (e.key === 'Escape') handleEditCancel();
+                            }}
+                          />
+                          <div className="flex items-center gap-2">
+                            <Tag className="w-3 h-3 text-muted-foreground" />
+                            <input
+                              type="text"
+                              className="ui-input w-32 rounded-md px-2 py-1 text-xs"
+                              placeholder="Project"
+                              value={editProject}
+                              onChange={(e) => setEditProject(e.target.value)}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Enter') handleEditSave();
+                                if (e.key === 'Escape') handleEditCancel();
+                              }}
+                            />
+                            <button
+                              type="button"
+                              className="ui-btn-primary px-2 py-1 text-[10px]"
+                              onClick={handleEditSave}
+                            >
+                              Save
+                            </button>
+                            <button
+                              type="button"
+                              className="ui-btn-secondary px-2 py-1 text-[10px]"
+                              onClick={handleEditCancel}
+                            >
+                              Cancel
+                            </button>
+                          </div>
+                        </div>
+                      ) : (
+                        <div>
+                          <p className={`text-sm ${item.completed ? 'line-through text-muted-foreground' : ''}`}>
+                            {item.text}
+                          </p>
+                          {item.project && (
+                            <button
+                              type="button"
+                              className="inline-flex rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary mt-1 hover:bg-primary/20 transition"
+                              onClick={() => setProjectFilter(item.project!)}
+                            >
+                              {item.project}
+                            </button>
+                          )}
+                        </div>
+                      )}
+                    </div>
+
+                    {/* Actions */}
+                    {!isEditing && (
+                      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+                        {/* Assign button — only for pending items with a project tag */}
+                        {item.project && !item.completed && !getAssignment(idx) && (
+                          <button
+                            type="button"
+                            className="ui-btn-icon h-7 w-7 !bg-transparent hover:!bg-primary/10 text-muted-foreground hover:!text-primary"
+                            onClick={() => handleAssign(idx)}
+                            disabled={assigningIndex === idx}
+                            title="Assign to Claude Code"
+                          >
+                            {assigningIndex === idx ? (
+                              <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                            ) : (
+                              <Zap className="w-3.5 h-3.5" />
+                            )}
+                          </button>
+                        )}
+                        {/* Assignment in-progress indicator */}
+                        {getAssignment(idx) && (
+                          <span className="inline-flex items-center gap-1 rounded-md bg-primary/15 px-1.5 py-0.5 text-[10px] font-semibold text-primary">
+                            <Loader2 className="w-3 h-3 animate-spin" />
+                            Assigned
+                          </span>
+                        )}
+                        <button
+                          type="button"
+                          className="ui-btn-icon h-7 w-7 !bg-transparent hover:!bg-muted"
+                          onClick={() => handleEditStart(idx, item)}
+                          title="Edit"
+                        >
+                          <Pencil className="w-3.5 h-3.5" />
+                        </button>
+                        <button
+                          type="button"
+                          className="ui-btn-icon h-7 w-7 !bg-transparent hover:!bg-destructive/10 text-muted-foreground hover:!text-destructive"
+                          onClick={() => handleDelete(idx)}
+                          title="Delete"
+                        >
+                          <Trash2 className="w-3.5 h-3.5" />
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/CronWidget.tsx
+++ b/src/components/CronWidget.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import Link from 'next/link';
+import { ChevronRight, ChevronDown, Clock } from 'lucide-react';
+
+type CronSchedule =
+  | { kind: 'at'; at: string }
+  | { kind: 'every'; everyMs: number; anchorMs?: number }
+  | { kind: 'cron'; expr: string; tz?: string };
+
+type CronPayload =
+  | { kind: 'systemEvent'; text: string }
+  | { kind: 'agentTurn'; message: string };
+
+type CronJobState = {
+  nextRunAtMs?: number;
+  lastRunAtMs?: number;
+  lastStatus?: 'ok' | 'error' | 'skipped';
+};
+
+type CronJob = {
+  id: string;
+  name: string;
+  enabled: boolean;
+  schedule: CronSchedule;
+  payload: CronPayload;
+  state: CronJobState;
+};
+
+const POLL_INTERVAL = 30_000;
+
+const formatSchedule = (schedule: CronSchedule): string => {
+  if (schedule.kind === 'every') {
+    const ms = schedule.everyMs;
+    if (ms % 86400000 === 0) return `${ms / 86400000}d`;
+    if (ms % 3600000 === 0) return `${ms / 3600000}h`;
+    if (ms % 60000 === 0) return `${ms / 60000}m`;
+    return `${ms / 1000}s`;
+  }
+  if (schedule.kind === 'cron') return schedule.expr;
+  return 'once';
+};
+
+const formatNextRun = (ms?: number): string | null => {
+  if (!ms) return null;
+  const diff = ms - Date.now();
+  if (diff < 0) return 'overdue';
+  if (diff < 60000) return `${Math.ceil(diff / 1000)}s`;
+  if (diff < 3600000) return `${Math.ceil(diff / 60000)}m`;
+  if (diff < 86400000) return `${Math.round(diff / 3600000)}h`;
+  return `${Math.round(diff / 86400000)}d`;
+};
+
+export const CronWidget = () => {
+  const [jobs, setJobs] = useState<CronJob[]>([]);
+  const [expanded, setExpanded] = useState(false);
+
+  const fetchJobs = useCallback(async () => {
+    try {
+      const response = await fetch('/api/cron');
+      if (response.ok) {
+        const result = await response.json();
+        setJobs(result.jobs || []);
+      }
+    } catch (err) {
+      console.error('Failed to fetch cron jobs:', err);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchJobs();
+    const interval = setInterval(fetchJobs, POLL_INTERVAL);
+    const handleVisibility = () => { if (!document.hidden) fetchJobs(); };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [fetchJobs]);
+
+  if (jobs.length === 0) return null;
+
+  const enabledJobs = jobs.filter(j => j.enabled);
+  const disabledJobs = jobs.filter(j => !j.enabled);
+  const errorJobs = jobs.filter(j => j.state.lastStatus === 'error');
+
+  // Find earliest next run
+  const nextRun = enabledJobs
+    .map(j => j.state.nextRunAtMs)
+    .filter((ms): ms is number => ms != null && ms > 0)
+    .sort((a, b) => a - b)[0];
+
+  return (
+    <div className="w-full ui-panel">
+      {/* Collapsed banner bar */}
+      <button
+        type="button"
+        className="flex w-full items-center justify-between px-4 py-2.5"
+        onClick={() => setExpanded(v => !v)}
+      >
+        <div className="flex items-center gap-3">
+          <span className="text-xs font-semibold tracking-wide uppercase text-muted-foreground">
+            Cron Jobs
+          </span>
+          <div className="flex items-center gap-2">
+            {enabledJobs.length > 0 && (
+              <span className="inline-flex items-center gap-1 rounded-md bg-green-500/15 px-2 py-0.5 text-[11px] font-semibold text-green-700 dark:text-green-400">
+                {enabledJobs.length} active
+              </span>
+            )}
+            {disabledJobs.length > 0 && (
+              <span className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+                {disabledJobs.length} disabled
+              </span>
+            )}
+            {errorJobs.length > 0 && (
+              <span className="inline-flex items-center gap-1 rounded-md bg-destructive/15 px-2 py-0.5 text-[11px] font-semibold text-destructive">
+                {errorJobs.length} error
+              </span>
+            )}
+            {nextRun && (
+              <span className="inline-flex items-center gap-1 text-[10px] text-muted-foreground">
+                <Clock className="w-3 h-3" />
+                next: {formatNextRun(nextRun)}
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Link
+            href="/cron"
+            className="text-xs text-primary hover:opacity-70 transition flex items-center gap-1"
+            onClick={e => e.stopPropagation()}
+          >
+            Manage <ChevronRight className="w-3 h-3" />
+          </Link>
+          {expanded ? (
+            <ChevronDown className="w-4 h-4 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="w-4 h-4 text-muted-foreground" />
+          )}
+        </div>
+      </button>
+
+      {/* Expanded details */}
+      {expanded && (
+        <div className="border-t border-border px-4 pb-3 pt-2 space-y-3 max-h-72 overflow-y-auto">
+          {/* Active jobs */}
+          {enabledJobs.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold text-muted-foreground mb-1.5">Active</p>
+              <div className="space-y-1.5">
+                {enabledJobs.map(job => (
+                  <div
+                    key={job.id}
+                    className="bg-green-500/10 border border-green-500/20 rounded-md p-2"
+                  >
+                    <div className="flex items-center justify-between">
+                      <p className="text-xs font-medium">{job.name}</p>
+                      <p className="text-[10px] text-muted-foreground font-mono">
+                        {formatSchedule(job.schedule)}
+                      </p>
+                    </div>
+                    <p className="text-[10px] text-muted-foreground mt-0.5 truncate">
+                      {job.payload.kind === 'systemEvent' ? job.payload.text : job.payload.message}
+                    </p>
+                    {job.state.nextRunAtMs && (
+                      <p className="text-[10px] text-muted-foreground mt-0.5">
+                        Next: {formatNextRun(job.state.nextRunAtMs)}
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Disabled jobs */}
+          {disabledJobs.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold text-muted-foreground mb-1.5">Disabled</p>
+              <div className="space-y-1.5">
+                {disabledJobs.map(job => (
+                  <div
+                    key={job.id}
+                    className="bg-muted/30 border border-muted/50 rounded-md p-2"
+                  >
+                    <div className="flex items-center justify-between">
+                      <p className="text-xs font-medium text-muted-foreground">{job.name}</p>
+                      <p className="text-[10px] text-muted-foreground font-mono">
+                        {formatSchedule(job.schedule)}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/SessionsWidget.tsx
+++ b/src/components/SessionsWidget.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import Link from 'next/link';
+import { ChevronRight, ChevronDown } from 'lucide-react';
+import type { Session, SessionsData } from '@/types/sessions';
+
+const POLL_INTERVAL = 20_000;
+
+const formatTime = (timestamp: string) => {
+  try {
+    const date = new Date(timestamp);
+    return date.toLocaleString();
+  } catch {
+    return timestamp;
+  }
+};
+
+const getElapsedTime = (startTime: string, endTime?: string) => {
+  try {
+    const start = new Date(startTime);
+    const end = endTime ? new Date(endTime) : new Date();
+    const diffMs = end.getTime() - start.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMins / 60);
+
+    if (diffHours > 0) {
+      return `${diffHours}h ${diffMins % 60}m`;
+    }
+    return `${diffMins}m`;
+  } catch {
+    return '-';
+  }
+};
+
+export const SessionsWidget = () => {
+  const [data, setData] = useState<SessionsData | null>(null);
+  const [expanded, setExpanded] = useState(false);
+  const prevPausedRef = useRef(0);
+
+  const fetchSessions = useCallback(async () => {
+    try {
+      const response = await fetch('/api/sessions');
+      if (response.ok) {
+        const result: SessionsData = await response.json();
+        setData(result);
+
+        // Auto-expand if a new paused session appeared
+        if (result.paused.length > prevPausedRef.current) {
+          setExpanded(true);
+        }
+        prevPausedRef.current = result.paused.length;
+      }
+    } catch (err) {
+      console.error('Failed to fetch sessions:', err);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSessions();
+
+    const interval = setInterval(fetchSessions, POLL_INTERVAL);
+
+    const handleVisibilityChange = () => {
+      if (!document.hidden) {
+        fetchSessions();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [fetchSessions]);
+
+  if (!data) return null;
+
+  const totalActive = data.active.length + data.paused.length + data.exited.length;
+  if (totalActive === 0 && data.completed.length === 0) return null;
+
+  const hasPaused = data.paused.length > 0;
+
+  return (
+    <div
+      className={`w-full ui-panel ${hasPaused ? 'session-needs-input' : ''}`}
+    >
+      {/* Collapsed banner bar */}
+      <button
+        type="button"
+        className="flex w-full items-center justify-between px-4 py-2.5"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <div className="flex items-center gap-3">
+          <span className="text-xs font-semibold tracking-wide uppercase text-muted-foreground">
+            Sessions
+          </span>
+          <div className="flex items-center gap-2">
+            {data.active.length > 0 && (
+              <span className="inline-flex items-center gap-1 rounded-md bg-green-500/15 px-2 py-0.5 text-[11px] font-semibold text-green-700 dark:text-green-400">
+                <span className="inline-block h-1.5 w-1.5 rounded-full bg-green-500 animate-pulse" />
+                {data.active.length} active
+              </span>
+            )}
+            {data.paused.length > 0 && (
+              <span className="inline-flex items-center gap-1 rounded-md bg-yellow-500/20 px-2 py-0.5 text-[11px] font-bold text-yellow-700 dark:text-yellow-400">
+                <span className="inline-block h-1.5 w-1.5 rounded-full bg-yellow-500 animate-pulse" />
+                {data.paused.length} needs input
+              </span>
+            )}
+            {data.exited.length > 0 && (
+              <span className="inline-flex items-center gap-1 rounded-md bg-orange-500/15 px-2 py-0.5 text-[11px] font-medium text-orange-700 dark:text-orange-400">
+                {data.exited.length} interrupted
+              </span>
+            )}
+            {data.completed.length > 0 && (
+              <span className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+                {data.completed.length} done
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Link
+            href="/sessions"
+            className="text-xs text-primary hover:opacity-70 transition flex items-center gap-1"
+            onClick={(e) => e.stopPropagation()}
+          >
+            View All <ChevronRight className="w-3 h-3" />
+          </Link>
+          {expanded ? (
+            <ChevronDown className="w-4 h-4 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="w-4 h-4 text-muted-foreground" />
+          )}
+        </div>
+      </button>
+
+      {/* Expanded details */}
+      {expanded && (
+        <div className="border-t border-border px-4 pb-3 pt-2 space-y-3 max-h-72 overflow-y-auto">
+          {/* Paused - most prominent */}
+          {data.paused.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold text-yellow-700 dark:text-yellow-400 mb-1.5">
+                Needs Your Input
+              </p>
+              <div className="space-y-1.5">
+                {data.paused.map((session) => (
+                  <div
+                    key={session.project}
+                    className="bg-yellow-500/15 border border-yellow-500/30 rounded-md p-2"
+                  >
+                    <p className="text-xs font-semibold">{session.project}</p>
+                    {session.details && (
+                      <p className="text-xs text-yellow-800 dark:text-yellow-300 mt-0.5">
+                        {session.details}
+                      </p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Active */}
+          {data.active.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold text-muted-foreground mb-1.5">Active</p>
+              <div className="space-y-1.5">
+                {data.active.map((session) => (
+                  <div
+                    key={session.project}
+                    className="bg-green-500/10 border border-green-500/20 rounded-md p-2"
+                  >
+                    <div className="flex items-center justify-between">
+                      <p className="text-xs font-medium">{session.project}</p>
+                      <p className="text-[10px] text-muted-foreground">
+                        {getElapsedTime(session.startTime)}
+                      </p>
+                    </div>
+                    {session.details && (
+                      <p className="text-[10px] text-muted-foreground mt-0.5">{session.details}</p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Interrupted */}
+          {data.exited.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold text-muted-foreground mb-1.5">Interrupted</p>
+              <div className="space-y-1.5">
+                {data.exited.map((session) => (
+                  <div
+                    key={`${session.project}-exited`}
+                    className="bg-orange-500/10 border border-orange-500/20 rounded-md p-2"
+                  >
+                    <p className="text-xs font-medium">{session.project}</p>
+                    {session.details && (
+                      <p className="text-[10px] text-muted-foreground mt-0.5">{session.details}</p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Completed */}
+          {data.completed.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold text-muted-foreground mb-1.5">Completed</p>
+              <div className="space-y-1.5">
+                {data.completed.map((session) => (
+                  <div
+                    key={`${session.project}-${session.endTime}`}
+                    className="bg-muted/30 border border-muted/50 rounded-md p-2"
+                  >
+                    <div className="flex items-center justify-between">
+                      <p className="text-xs font-medium">{session.project}</p>
+                      {session.endTime && (
+                        <p className="text-[10px] text-muted-foreground">
+                          {getElapsedTime(session.startTime, session.endTime)}
+                        </p>
+                      )}
+                    </div>
+                    {session.details && (
+                      <p className="text-[10px] text-muted-foreground mt-0.5">{session.details}</p>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/TodosWidget.tsx
+++ b/src/components/TodosWidget.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import Link from 'next/link';
+import { ChevronRight, ChevronDown, Plus, Check, Zap } from 'lucide-react';
+import type { TodoItem, TodosData } from '@/types/todos';
+
+type Assignment = {
+  status: 'in_progress' | 'completed' | 'failed';
+};
+
+const POLL_INTERVAL = 30_000;
+
+export const TodosWidget = () => {
+  const [data, setData] = useState<TodosData | null>(null);
+  const [expanded, setExpanded] = useState(false);
+  const [quickAddText, setQuickAddText] = useState('');
+  const [busy, setBusy] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [activeAssignments, setActiveAssignments] = useState(0);
+
+  const fetchTodos = useCallback(async () => {
+    try {
+      const response = await fetch('/api/todos');
+      if (response.ok) {
+        const result: TodosData = await response.json();
+        setData(result);
+      }
+    } catch (err) {
+      console.error('Failed to fetch todos:', err);
+    }
+    try {
+      const response = await fetch('/api/assign');
+      if (response.ok) {
+        const result = await response.json();
+        const active = (result.assignments || []).filter(
+          (a: Assignment) => a.status === 'in_progress'
+        ).length;
+        setActiveAssignments(active);
+      }
+    } catch {
+      // Assignments are optional
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchTodos();
+    const interval = setInterval(fetchTodos, POLL_INTERVAL);
+    const handleVisibility = () => { if (!document.hidden) fetchTodos(); };
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [fetchTodos]);
+
+  const handleQuickAdd = async () => {
+    if (!quickAddText.trim() || busy) return;
+    setBusy(true);
+    try {
+      const res = await fetch('/api/todos', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: quickAddText.trim() }),
+      });
+      if (res.ok) {
+        const { items } = await res.json();
+        setData((prev) => prev ? { ...prev, items } : prev);
+        setQuickAddText('');
+      }
+    } catch (err) {
+      console.error('Quick add failed:', err);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleToggle = async (index: number, completed: boolean) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const res = await fetch('/api/todos', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ index, completed: !completed }),
+      });
+      if (res.ok) {
+        const { items } = await res.json();
+        setData((prev) => prev ? { ...prev, items } : prev);
+      }
+    } catch (err) {
+      console.error('Toggle failed:', err);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!data) return null;
+
+  const pending = data.items.filter((i) => !i.completed);
+  const completed = data.items.filter((i) => i.completed);
+
+  if (pending.length === 0 && completed.length === 0) return null;
+
+  return (
+    <div className="w-full ui-panel">
+      {/* Collapsed banner bar */}
+      <button
+        type="button"
+        className="flex w-full items-center justify-between px-4 py-2.5"
+        onClick={() => setExpanded((v) => !v)}
+      >
+        <div className="flex items-center gap-3">
+          <span className="text-xs font-semibold tracking-wide uppercase text-muted-foreground">
+            Captures
+          </span>
+          <div className="flex items-center gap-2">
+            {pending.length > 0 && (
+              <span className="inline-flex items-center gap-1 rounded-md bg-primary/15 px-2 py-0.5 text-[11px] font-semibold text-primary">
+                {pending.length} pending
+              </span>
+            )}
+            {activeAssignments > 0 && (
+              <span className="inline-flex items-center gap-1 rounded-md bg-primary/15 px-2 py-0.5 text-[11px] font-semibold text-primary">
+                <Zap className="w-3 h-3" />
+                {activeAssignments} assigned
+              </span>
+            )}
+            {completed.length > 0 && (
+              <span className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+                {completed.length} done
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Link
+            href="/todos"
+            className="text-xs text-primary hover:opacity-70 transition flex items-center gap-1"
+            onClick={(e) => e.stopPropagation()}
+          >
+            Manage <ChevronRight className="w-3 h-3" />
+          </Link>
+          {expanded ? (
+            <ChevronDown className="w-4 h-4 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="w-4 h-4 text-muted-foreground" />
+          )}
+        </div>
+      </button>
+
+      {/* Expanded details */}
+      {expanded && (
+        <div className="border-t border-border px-4 pb-3 pt-2 space-y-3 max-h-72 overflow-y-auto">
+          {/* Quick add */}
+          <div className="flex gap-2" onClick={(e) => e.stopPropagation()}>
+            <input
+              ref={inputRef}
+              type="text"
+              className="ui-input flex-1 rounded-md px-2.5 py-1.5 text-xs"
+              placeholder="Quick add..."
+              value={quickAddText}
+              onChange={(e) => setQuickAddText(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleQuickAdd();
+              }}
+            />
+            <button
+              type="button"
+              className="ui-btn-primary px-2 py-1.5 text-[10px] font-medium flex items-center gap-1"
+              onClick={handleQuickAdd}
+              disabled={busy || !quickAddText.trim()}
+            >
+              <Plus className="w-3 h-3" />
+              Add
+            </button>
+          </div>
+
+          {/* Pending items with quick toggle */}
+          {pending.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold text-muted-foreground mb-1.5">Pending</p>
+              <div className="space-y-1">
+                {pending.map((item) => {
+                  const globalIdx = data.items.indexOf(item);
+                  return (
+                    <div key={globalIdx} className="flex items-start gap-2 text-xs group">
+                      <button
+                        type="button"
+                        className="mt-0.5 flex-shrink-0 h-4 w-4 rounded border border-border hover:border-primary/50 flex items-center justify-center transition-colors"
+                        onClick={(e) => { e.stopPropagation(); handleToggle(globalIdx, item.completed); }}
+                      />
+                      <div className="flex-1 min-w-0">
+                        <span>{item.text}</span>
+                        {item.project && (
+                          <span className="ml-1.5 inline-flex rounded bg-primary/10 px-1 py-0.5 text-[9px] font-medium text-primary">
+                            {item.project}
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* Completed (collapsed summary) */}
+          {completed.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold text-muted-foreground mb-1.5">
+                Completed ({completed.length})
+              </p>
+              <div className="space-y-1">
+                {completed.slice(0, 3).map((item) => {
+                  const globalIdx = data.items.indexOf(item);
+                  return (
+                    <div key={globalIdx} className="flex items-start gap-2 text-xs text-muted-foreground">
+                      <button
+                        type="button"
+                        className="mt-0.5 flex-shrink-0 h-4 w-4 rounded border border-primary/30 bg-primary/10 flex items-center justify-center"
+                        onClick={(e) => { e.stopPropagation(); handleToggle(globalIdx, item.completed); }}
+                      >
+                        <Check className="w-2.5 h-2.5 text-primary" />
+                      </button>
+                      <span className="line-through">{item.text}</span>
+                    </div>
+                  );
+                })}
+                {completed.length > 3 && (
+                  <Link
+                    href="/todos"
+                    className="text-[10px] text-primary hover:opacity-70 ml-6"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    +{completed.length - 3} more...
+                  </Link>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/types/sessions.ts
+++ b/src/types/sessions.ts
@@ -1,0 +1,15 @@
+export interface Session {
+  project: string;
+  status: 'active' | 'paused' | 'completed' | 'exited';
+  startTime: string;
+  endTime?: string;
+  details?: string;
+}
+
+export interface SessionsData {
+  active: Session[];
+  paused: Session[];
+  completed: Session[];
+  exited: Session[];
+  lastUpdated: string;
+}

--- a/src/types/todos.ts
+++ b/src/types/todos.ts
@@ -1,0 +1,11 @@
+export interface TodoItem {
+  text: string;
+  project?: string;
+  completed: boolean;
+  source: 'captures';
+}
+
+export interface TodosData {
+  items: TodoItem[];
+  lastUpdated: string;
+}


### PR DESCRIPTION
## Summary
- **Cron Jobs page** (`/cron`): Full CRUD management for scheduled jobs — create, edit, delete, toggle enable/disable. Supports interval, cron expression, and one-time schedules. Includes expandable reports viewer per job and configurable Telegram delivery notifications.
- **Sessions page** (`/sessions`): View active, paused, completed, and interrupted Claude sessions with auto-polling and status indicators.
- **Captures & TODOs page** (`/todos`): Manage items from `CAPTURES.md` with project tag filtering, inline completion, and deletion.
- **Dashboard widgets**: `CronWidget`, `SessionsWidget`, and `TodosWidget` on the main page for at-a-glance status.

All pages use client-side polling with visibility-change refetch for real-time updates.

## New files
- `src/app/cron/page.tsx` — cron management page
- `src/app/sessions/page.tsx` — sessions page
- `src/app/todos/page.tsx` — captures/TODOs page
- `src/app/api/cron/route.ts` — CRUD API for jobs.json
- `src/app/api/cron/reports/route.ts` — report file viewer API
- `src/app/api/sessions/route.ts` — sessions API
- `src/app/api/todos/route.ts` — TODOs API
- `src/components/CronWidget.tsx` — dashboard widget
- `src/components/SessionsWidget.tsx` — dashboard widget
- `src/components/TodosWidget.tsx` — dashboard widget
- `src/types/sessions.ts`, `src/types/todos.ts` — shared types

## Test plan
- [ ] `npm run build` passes cleanly
- [ ] `/cron` page loads, can add/edit/delete/toggle jobs
- [ ] `/sessions` page loads and displays session data
- [ ] `/todos` page loads and displays captures
- [ ] Dashboard widgets render on main page
- [ ] Reports viewer expands and shows file contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)