### PR TITLE
ci: add GitHub Actions workflow for lint, typecheck, and unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20, 22]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Unit tests
+        run: npm test -- --run


### PR DESCRIPTION
Closes #83

- Runs on PRs and pushes to main
- Matrix tests across Node 20 and 22
- Covers lint, typecheck, and unit tests
- Skips e2e (known failures on main, tracked in #84)

## Summary
- Add GitHub Actions CI workflow for lint, typecheck, and unit tests
- Matrix tests across Node 20 and 22
- Runs on PRs to main and pushes to main

## Testing
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (790/790 passing)
- [ ] `npm run e2e` (known failures on main, tracked in #84)

## AI-assisted
- [ ] AI-assisted
