### PR TITLE
fix: wrap root page in Suspense to fix production builds

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { AgentChatPanel } from "@/features/agents/components/AgentChatPanel";
 import { AgentCreateModal } from "@/features/agents/components/AgentCreateModal";
@@ -1834,11 +1834,12 @@ const AgentStudioPage = () => {
     </div>
   );
 };
-
 export default function Home() {
   return (
-    <AgentStoreProvider>
-      <AgentStudioPage />
-    </AgentStoreProvider>
+    <Suspense>
+      <AgentStoreProvider>
+        <AgentStudioPage />
+      </AgentStoreProvider>
+    </Suspense>
   );
 }


### PR DESCRIPTION
Fixes #87

- Add Suspense boundary around useSearchParams consumer
- Enables next build to complete successfully
- Reduces RAM usage from ~728MB (dev) to ~90MB (production)
- Reduces page serve time from ~2s to ~25ms

## Summary
- Wrap root page component in `<Suspense>` to fix `next build` failure
- `useSearchParams()` requires a Suspense boundary since Next.js 14+
- Without this fix, Studio can only run in dev mode

## Impact
| | Dev mode (before) | Production mode (after) |
|---|---|---|
| RAM usage | ~728 MB | ~90 MB |
| Page serve time | 1.8–2.2s | ~25 ms |

On 2GB VPS hosts, dev mode OOM-kills the gateway. This fix makes production deployments viable.

## Testing
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test` (790/790 passing)
- [x] `npm run build` (succeeds — previously failed)

## AI-assisted
- [ ] AI-assisted

