### PR TITLE
fix: use minProtocol: 3 instead of args.protocol in connect params

### DIFF
--- a/src/lib/controlplane/gateway-connect-profile.ts
+++ b/src/lib/controlplane/gateway-connect-profile.ts
@@ -76,7 +76,7 @@ export function buildGatewayConnectProfile(args: {
   capabilities: string[];
 }): GatewayConnectProfile {
   const baseParams = {
-    minProtocol: args.protocol,
+    minProtocol: 3,
     maxProtocol: args.protocol,
     role: "operator" as const,
     scopes: [...OPERATOR_SCOPES],


### PR DESCRIPTION
## Summary
- Fix gateway handshake failure by using explicit `minProtocol: 3` instead of `args.protocol`
- The ACP protocol requires minProtocol/maxProtocol as separate integer fields

## Changes
- `src/lib/controlplane/gateway-connect-profile.ts`: Changed `minProtocol: args.protocol` to `minProtocol: 3`

## Test plan
- [x] Unit test verifies minProtocol and maxProtocol are present in connect request
- [ ] Verify gateway handshake succeeds with the fix

Fixes #101